### PR TITLE
feat: Upgrade Spring Boot to 3.5.14. Upgrade related dependencies too

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -24,7 +24,7 @@ jobs:
     if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -15,10 +15,10 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: restore-cache
         with:
           path: .lycheecache

--- a/.github/workflows/maven-central-snapshot-deploy.yaml
+++ b/.github/workflows/maven-central-snapshot-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-# The workflow to deploy snapshot artifact versions to Maven Central
+# The workflow to deploy snapshot artifact versions to GitHub Packages
 # Fill free to adjust java version and additional mvn command-line parameters
 # The workflow will trigger on pushes into branches different from main and release
 # Please make sure that the version in the pom.xml file has the SNAPSHOT postfix
@@ -25,15 +25,24 @@ permissions:
   contents: read
   packages: write
 
+env:
+  additional-mvn-args: ""
+
 jobs:
   mvn-snapshot-deploy:
-    uses: netcracker/qubership-workflow-hub/.github/workflows/re-maven-snapshot-deploy.yaml@v1.0.7
-    with:
-      java-version: "21"
-      additional-mvn-args: ""
-      target-store: "maven-central"
-    secrets:
-      maven-username: ${{ secrets.MAVEN_USER }}
-      maven-token: ${{ secrets.MAVEN_PASSWORD }}
-      gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Maven Docker build
+        id: maven_build
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@d11baa8a4b42d1a931808c0766ee23eb344c47dd # v2.2.0
+        with:
+          java-version: "21"
+          additional-mvn-args: ${{ env.additional-mvn-args }}
+          target-store: "github"
+          maven-username: ${{ github.ACTOR }}
+          maven-token: ${{ secrets.GITHUB_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG-PASSPHRASE }}

--- a/.github/workflows/maven-release-v2.yaml
+++ b/.github/workflows/maven-release-v2.yaml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Build and Publish current SNAPSHOT (dry run)"
-        uses: netcracker/qubership-workflow-hub/actions/maven-release@v1.0.3
+        uses: netcracker/qubership-workflow-hub/actions/maven-release@v2.2.0
         with:
           java-version: "21"
           version-type: ${{ github.event.inputs.version-type }}
@@ -89,14 +89,14 @@ jobs:
     steps:
       # This step is needed if there is a GitHub App used for authentication to bypass the protected branch rule
       - name: "Prepare app token"
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.GH_BUMP_VERSION_APP_ID }}
           private-key: ${{ secrets.GH_BUMP_VERSION_APP_KEY }}
       - name: "Build and Publish"
         id: build-and-publish
-        uses: netcracker/qubership-workflow-hub/actions/maven-release@v1.0.3
+        uses: netcracker/qubership-workflow-hub/actions/maven-release@v2.2.0
         with:
           java-version: "21"
           version-type: ${{ github.event.inputs.version-type }}
@@ -112,7 +112,7 @@ jobs:
           gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
           dry-run: 'false'
       - name: Upload all Maven target directories
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.event.repository.name }}
           path: '**/target'
@@ -123,7 +123,7 @@ jobs:
     outputs:
       dockerfile_exists: ${{ steps.check_dockerfile.outputs.df_exists }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Check Dockerfile existence"
         id: check_dockerfile
         shell: bash
@@ -157,7 +157,7 @@ jobs:
   github-release:
     needs: [deploy]
     if: ${{ needs.deploy.result == 'success' }}
-    uses: netcracker/qubership-workflow-hub/.github/workflows/release-drafter.yml@v1.0.3
+    uses: netcracker/qubership-workflow-hub/.github/workflows/release-drafter.yml@v2.2.0
     with:
       version: ${{ needs.deploy.outputs.release-version }}
       publish: true

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -22,10 +22,10 @@ jobs:
             exit 0
           fi
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: netcracker/qubership-workflow-hub/actions/pr-assigner@b575bad3a0959c4e883bc34f9d055ff07fde2dbd #2.0.1
+      - uses: netcracker/qubership-workflow-hub/actions/pr-assigner@d11baa8a4b42d1a931808c0766ee23eb344c47dd #2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -16,8 +16,8 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
+      - uses: webiny/action-conventional-commits@faccb24fc2550dd15c0390d944379d2d8ed9690e # v1.3.1

--- a/.github/workflows/profanity-filter.yaml
+++ b/.github/workflows/profanity-filter.yaml
@@ -17,13 +17,13 @@ jobs:
   apply-filter:
     runs-on: ubuntu-latest
     steps:
-    - name: Scan issue or pull request for profanity
-      # Conditionally run the step if the actor isn't a bot
-      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
-      uses: IEvangelist/profanity-filter@9.07
-      id: profanity-filter
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # See https://bit.ly/potty-mouth-replacement-strategies
-        replacement-strategy: middle-asterisk # See Replacement strategy
-        custom-profane-words-url: https://github.com/Hesham-Elbadawi/list-of-banned-words/raw/refs/heads/master/ru
+      - name: Scan issue or pull request for profanity
+        # Conditionally run the step if the actor isn't a bot
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+        uses: IEvangelist/profanity-filter@10.0
+        id: profanity-filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # See https://bit.ly/potty-mouth-replacement-strategies
+          replacement-strategy: middle-asterisk # See Replacement strategy
+          custom-profane-words-url: https://github.com/Hesham-Elbadawi/list-of-banned-words/raw/refs/heads/master/ru

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -32,20 +32,20 @@ jobs:
   prepare-configs:
     runs-on: ubuntu-latest
     steps:
-    - name: "Get the common linters configuration"
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        ref: main # fix/superlinter-config
-        repository: netcracker/.github
-        persist-credentials: false
-        sparse-checkout: |
-          config/linters
-    - name: "Upload the common linters configuration"
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      with:
-        name: linter-config
-        path: "${{ github.workspace }}/config"
-        include-hidden-files: true
+      - name: "Get the common linters configuration"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main # fix/superlinter-config
+          repository: netcracker/.github
+          persist-credentials: false
+          sparse-checkout: |
+            config/linters
+      - name: "Upload the common linters configuration"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linter-config
+          path: "${{ github.workspace }}/config"
+          include-hidden-files: true
   run-lint:
     needs: [prepare-configs]
     runs-on: ubuntu-latest
@@ -55,44 +55,44 @@ jobs:
       # To report GitHub Actions status checks
       statuses: write
     steps:
-    - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        # Full git history is needed to get a proper list of changed files within `super-linter`
-        fetch-depth: 0
-        persist-credentials: false
-    - name: "Get the common linters configuration"
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-      id: download
-      with:
-        name: linter-config
-        path: /tmp/linter-config
-    - name: "Apply the common linters configuration"
-      if: ${{ steps.download.outputs.download-path != '' }}
-      run: |
-        mkdir -p ./.github/linters
-        cp --update=none -vRT /tmp/linter-config/linters ./.github/linters
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Get the common linters configuration"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        id: download
+        with:
+          name: linter-config
+          path: /tmp/linter-config
+      - name: "Apply the common linters configuration"
+        if: ${{ steps.download.outputs.download-path != '' }}
+        run: |
+          mkdir -p ./.github/linters
+          cp --update=none -vRT /tmp/linter-config/linters ./.github/linters
 
-    - name: "Load super-linter environment file"
-      shell: bash
-      run: |
-        # shellcheck disable=2086
-        if [ -f "${GITHUB_WORKSPACE}/.github/super-linter.env" ]; then
-          echo "Applying local linter environment:"
-          grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#"
-          grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#" >> $GITHUB_ENV
-        elif [ -f "/tmp/linter-config/linters/super-linter.env" ]; then
-          echo "::warning:: Local linter environment file .github/super-linter.env is not found"
-          echo "Applying common linter environment:"
-          grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#"
-          grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#" >> $GITHUB_ENV
-        fi
+      - name: "Load super-linter environment file"
+        shell: bash
+        run: |
+          # shellcheck disable=2086
+          if [ -f "${GITHUB_WORKSPACE}/.github/super-linter.env" ]; then
+            echo "Applying local linter environment:"
+            grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#"
+            grep "\S" ${GITHUB_WORKSPACE}/.github/super-linter.env | grep -v "^#" >> $GITHUB_ENV
+          elif [ -f "/tmp/linter-config/linters/super-linter.env" ]; then
+            echo "::warning:: Local linter environment file .github/super-linter.env is not found"
+            echo "Applying common linter environment:"
+            grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#"
+            grep "\S" /tmp/linter-config/linters/super-linter.env | grep -v "^#" >> $GITHUB_ENV
+          fi
 
-    - name: Lint Code Base
-      uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
-      env:
-        VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
-        # To report GitHub Actions status checks
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref || github.event.push.ref }}
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        env:
+          VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref || github.event.push.ref }}
 

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -4,14 +4,14 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-    <version>4.5.73-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>parent-dependencies</name>
 
     <properties>
         <java.version>21</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.13</logback.version>
         <junit.version>4.13.2</junit.version>
@@ -20,16 +20,16 @@
         <h2.version>1.4.195</h2.version>
         <postgesql.version>42.1.1</postgesql.version>
         <liquibase.version>3.5.3</liquibase.version>
-        <guice.version>4.1.0</guice.version>
+        <guice.version>5.1.0</guice.version>
         <jackson.annotations.version>2.8.4</jackson.annotations.version>
-        <org.apache.httpcomponents>4.5.13</org.apache.httpcomponents>
+        <org.apache.httpcomponents>4.5.14</org.apache.httpcomponents>
         <kafka.clients>3.1.2</kafka.clients>
 
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.44</lombok.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <crypt.version>0.0.20</crypt.version>
+        <crypt.version>1.0.0-SNAPSHOT</crypt.version>
         <ram.model.version>2.2.204</ram.model.version>
     </properties>
 
@@ -290,6 +290,10 @@
                     <exclusion>
                         <groupId>commons-lang</groupId>
                         <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>parent-dependencies</name>
 
@@ -28,11 +28,11 @@
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
         <lombok.version>1.18.46</lombok.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <crypt.version>1.0.0-SNAPSHOT</crypt.version>
-        <ram.model.version>2.2.204</ram.model.version>
-
         <httpclient5.version>5.4.4</httpclient5.version>
         <httpcore5.version>5.3.4</httpcore5.version>
+
+        <crypt.version>1.0.1-SNAPSHOT</crypt.version>
+        <ram.model.version>2.2.204</ram.model.version>
     </properties>
 
     <description>Qubership Testing Platform Adapter Robot library</description>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -31,7 +31,7 @@
         <httpclient5.version>5.4.4</httpclient5.version>
         <httpcore5.version>5.3.4</httpcore5.version>
 
-        <crypt.version>1.0.1-SNAPSHOT</crypt.version>
+        <crypt.version>1.0.0</crypt.version>
         <ram.model.version>2.2.204</ram.model.version>
     </properties>
 
@@ -300,6 +300,45 @@
                 <groupId>org.qubership.atp.ram</groupId>
                 <artifactId>qubership-atp-ram-model</artifactId>
                 <version>${ram.model.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-handler</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.undertow</groupId>
+                        <artifactId>undertow-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-web</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.qubership.atp.auth</groupId>
+                        <artifactId>atp-auth-spring-boot-starter</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.data</groupId>
+                        <artifactId>spring-data-mongodb</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>org.qubership.atp.adapter.robot</groupId>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>parent-dependencies</name>
 

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -12,22 +12,22 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.32</logback.version>
         <hikariCP.version>2.6.2</hikariCP.version>
         <querydsl.version>4.1.4</querydsl.version>
         <h2.version>1.4.195</h2.version>
-        <postgesql.version>42.1.1</postgesql.version>
+        <postgesql.version>42.7.7</postgesql.version>
         <liquibase.version>3.5.3</liquibase.version>
         <guice.version>5.1.0</guice.version>
-        <jackson.annotations.version>2.8.4</jackson.annotations.version>
+        <jackson.version>2.18.6</jackson.version>
         <org.apache.httpcomponents>4.5.14</org.apache.httpcomponents>
-        <kafka.clients>3.1.2</kafka.clients>
+        <kafka.clients>3.9.2</kafka.clients>
 
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
         <lombok.version>1.18.46</lombok.version>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <httpcore5.version>5.3.4</httpcore5.version>
 
@@ -206,7 +206,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <dependency>
@@ -215,19 +220,11 @@
                 <version>${kafka.clients}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>2.12.7</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.12.7</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.12.7.1</version>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -249,7 +246,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>22.0</version>
+                <version>32.0.1-jre</version>
             </dependency>
 
             <dependency>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -307,6 +307,12 @@
                 <artifactId>qubership-atp-adapter-robot</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>2.1.1</version>
+                <scope>compile</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -31,6 +31,9 @@
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <crypt.version>1.0.0-SNAPSHOT</crypt.version>
         <ram.model.version>2.2.204</ram.model.version>
+
+        <httpclient5.version>5.4.4</httpclient5.version>
+        <httpcore5.version>5.3.4</httpcore5.version>
     </properties>
 
     <description>Qubership Testing Platform Adapter Robot library</description>
@@ -312,6 +315,26 @@
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>2.1.1</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-fluent</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -26,7 +26,7 @@
 
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
-        <lombok.version>1.18.44</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <crypt.version>1.0.0-SNAPSHOT</crypt.version>
         <ram.model.version>2.2.204</ram.model.version>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -14,18 +14,12 @@
         <maven.compiler.target>21</maven.compiler.target>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.32</logback.version>
-        <hikariCP.version>2.6.2</hikariCP.version>
-        <querydsl.version>4.1.4</querydsl.version>
         <h2.version>1.4.195</h2.version>
-        <postgesql.version>42.7.7</postgesql.version>
-        <liquibase.version>3.5.3</liquibase.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.18.6</jackson.version>
         <org.apache.httpcomponents>4.5.14</org.apache.httpcomponents>
         <kafka.clients>3.9.2</kafka.clients>
 
-        <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
-        <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
         <lombok.version>1.18.46</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <httpclient5.version>5.4.4</httpclient5.version>

--- a/parent/parent-dependencies/pom.xml
+++ b/parent/parent-dependencies/pom.xml
@@ -13,8 +13,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <slf4j.version>1.7.25</slf4j.version>
-        <logback.version>1.2.13</logback.version>
-        <junit.version>4.13.2</junit.version>
+        <logback.version>1.5.32</logback.version>
         <hikariCP.version>2.6.2</hikariCP.version>
         <querydsl.version>4.1.4</querydsl.version>
         <h2.version>1.4.195</h2.version>
@@ -187,6 +186,12 @@
                 <groupId>org.qubership.atp</groupId>
                 <artifactId>atp-crypt</artifactId>
                 <version>${crypt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -240,12 +245,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/parent/parent-java/pom.xml
+++ b/parent/parent-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/parent/parent-java/pom.xml
+++ b/parent/parent-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/parent/parent-java/pom.xml
+++ b/parent/parent-java/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>4.5.73-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent-dependencies/pom.xml</relativePath>
     </parent>
 
@@ -49,10 +49,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.15.0</version>
                     <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <annotationProcessorPaths>
                             <path>
@@ -71,6 +69,7 @@
                                 <version>0.2.0</version>
                             </path>
                         </annotationProcessorPaths>
+                        <release>${java.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -126,7 +125,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.1.2</version>
                     <configuration>
                         <argLine>--add-opens java.base/java.util.stream=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                         <systemPropertyVariables>

--- a/parent/parent-java/pom.xml
+++ b/parent/parent-java/pom.xml
@@ -39,9 +39,9 @@
     <scm>
         <connection>scm:git:https//github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</connection>
         <developerConnection>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</developerConnection>
-        <url>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/tree/main</url>
-      <tag>HEAD</tag>
-  </scm>
+        <url>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <pluginManagement>
@@ -51,6 +51,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.15.0</version>
                     <configuration>
+                        <release>${java.version}</release>
+                        <parameters>true</parameters>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <annotationProcessorPaths>
                             <path>
@@ -69,7 +71,6 @@
                                 <version>0.2.0</version>
                             </path>
                         </annotationProcessorPaths>
-                        <release>${java.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <targetJdk>21</targetJdk>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
         <lombok.version>1.18.44</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-aggregator</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <connection>scm:git:https//github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</connection>
         <developerConnection>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</developerConnection>
         <url>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-aggregator</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,21 +4,21 @@
 
     <groupId>org.qubership.atp.adapter.robot</groupId>
     <artifactId>qubership-atp-adapter-robot-aggregator</artifactId>
-    <version>4.5.73-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <java.version>21</java.version>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <targetJdk>21</targetJdk>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.44</lombok.version>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -41,9 +41,9 @@
     <scm>
         <connection>scm:git:https//github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</connection>
         <developerConnection>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</developerConnection>
-        <url>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/tree/main</url>
+        <url>scm:git:https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library.git</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <modules>
         <module>parent/parent-dependencies</module>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mapstruct.version>1.6.3</mapstruct.version>
-        <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
-        <maven-pmd-plugin.version>3.8</maven-pmd-plugin.version>
         <lombok.version>1.18.44</lombok.version>
     </properties>
 

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>4.5.73-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 
@@ -46,8 +46,9 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
@@ -63,12 +64,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -89,6 +84,10 @@
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -103,9 +102,9 @@
             <version>3.2.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
         </dependency>
 
         <dependency>
@@ -152,7 +151,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.0</version>
+            <version>5.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -48,12 +48,18 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4.4</version>
         </dependency>
-
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5-fluent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
         </dependency>
 
         <dependency>

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -116,24 +116,6 @@
         <dependency>
             <groupId>org.qubership.atp.ram</groupId>
             <artifactId>qubership-atp-ram-model</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>netty-handler</artifactId>
-                    <groupId>io.netty</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>undertow-core</artifactId>
-                    <groupId>io.undertow</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spring-security-web</artifactId>
-                    <groupId>org.springframework.security</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spring-security-core</artifactId>
-                    <groupId>org.springframework.security</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -171,7 +153,10 @@
             <artifactId>commons-pool2</artifactId>
             <version>2.6.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.qubership.atp</groupId>
             <artifactId>atp-crypt</artifactId>

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -138,12 +138,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.118.Final</version>
+            <version>4.1.132.Final</version>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>2.2.39.Final</version>
+            <version>2.3.21.Final</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/qubership-atp-adapter-common/pom.xml
+++ b/qubership-atp-adapter-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
@@ -46,9 +46,9 @@ import java.util.UUID;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hc.client5.http.fluent.Content;
+import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.http.client.fluent.Content;
-import org.apache.http.client.fluent.Request;
 import org.qubership.atp.adapter.common.AtpRamAdapter;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.error.AdapterMethodIsNotSupported;
@@ -1289,21 +1289,21 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         String output;
         try {
             final Content postResult = RequestUtils.getHttpExecutor()
-                    .execute(Request.Post(atpRamUrl + "/api/mail/send/er/report")
+                    .execute(Request.post(atpRamUrl + "/api/mail/send/er/report")
                             .bodyString(params.toString(), ContentType.APPLICATION_JSON)).returnContent();
             output = postResult.asString();
             if (log.isDebugEnabled()) {
-                log.debug("Send report response: " + output);
+                log.debug("Send report response: {}", output);
             }
             final Content getResult = RequestUtils.getHttpExecutor()
-                    .execute(Request.Get(atpRamUrl
+                    .execute(Request.get(atpRamUrl
                             + RamConstants.RAM_EXECUTOR_PATH
                             + RamConstants.EXECUTION_REQUESTS_PATH
                             + "/" + executionRequestUuid
                             + RamConstants.STOP_PATH)).returnContent();
             output = getResult.asString();
             if (log.isDebugEnabled()) {
-                log.debug("Stop ER response: " + output);
+                log.debug("Stop ER response: {}", output);
             }
         } catch (Exception io) {
             log.error("Error due sending report: ", io);
@@ -1379,7 +1379,7 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
 
         if (section.getTestingStatus().getId() < recordStatus.getId()) {
             section.setTestingStatus(recordStatus);
-            setCompaundStatus(context.getAtpCompaund(), recordStatus);
+            setCompoundStatus(context.getAtpCompaund(), recordStatus);
         }
     }
 
@@ -1406,14 +1406,14 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         updateSectionTestRunStatus(status);
     }
 
-    private void setCompaundStatus(AtpCompaund compaund, TestingStatuses recordStatus) {
+    private void setCompoundStatus(AtpCompaund compaund, TestingStatuses recordStatus) {
         if (Objects.nonNull(compaund)) {
             if (isNull(compaund.getTestingStatuses()) || compaund.getTestingStatuses().getId() < recordStatus.getId()) {
                 log.debug("Setting compaund with id {} to status {}", compaund.getSectionId(),
                         recordStatus);
                 compaund.setTestingStatuses(recordStatus);
             }
-            setCompaundStatus(compaund.getParentSection(), recordStatus);
+            setCompoundStatus(compaund.getParentSection(), recordStatus);
         }
     }
 

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
@@ -45,9 +45,9 @@ import java.util.UUID;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.http.client.fluent.Content;
 import org.apache.http.client.fluent.Request;
-import org.apache.http.entity.ContentType;
 import org.qubership.atp.adapter.common.AtpRamAdapter;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.error.AdapterMethodIsNotSupported;
@@ -214,7 +214,7 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         } catch (IOException ioException) {
             log.error("Failed to create ER!", ioException);
             throw new FailedToCreateRamEntity(
-                    String.format("Failed to create ER with name %s", executionRequest),
+                "Failed to create ER with name %s".formatted(executionRequest),
                     ioException);
         }
     }
@@ -659,14 +659,14 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
             log.debug("Close section with ID {}", section.getUuid());
 
             TestingStatuses status = section.getTestingStatus();
-            if (section instanceof CompoundLogRecordContainer) {
+            if (section instanceof CompoundLogRecordContainer container) {
                 boolean isCompoundStatusUpdate = context.isParentStatusUpdate();
 
                 TestingStatuses parentCompoundStatus = context.getSections().empty()
                         ? null : context.getSections().peek().getTestingStatus();
                 context.setParentStatusUpdate(
                         Objects.nonNull(parentCompoundStatus) && !parentCompoundStatus.equals(status));
-                if (isCompoundStatusUpdate || ((CompoundLogRecordContainer) section).isStep()) {
+                if (isCompoundStatusUpdate || container.isStep()) {
                     updateSectionStatus(status.name());
                     context = updateTestingStatus(section.getUuid().toString(), status.toString());
                 }
@@ -706,7 +706,7 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
 
             LogRecord logRecord = createLogRecord(message, false, false);
 
-            if (logRecord instanceof UiLogRecord) {
+            if (logRecord instanceof UiLogRecord record) {
                 log.debug("Configured log record (Ui Log Record) with ID {} message {}", logRecord.getUuid(),
                         logRecord.getMessage());
                 updateSectionStatus(message.getTestingStatus());
@@ -716,7 +716,7 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
                 if (CollectionUtils.isNotEmpty(message.getBrowserLogs())) {
                     sendBrowserLogs(message.getBrowserLogs(), message.getUuid());
                 }
-                return sendUiLogRecord((UiLogRecord) logRecord);
+                return sendUiLogRecord(record);
             }
 
             log.debug("Configured log record (message) with ID {} message {}", logRecord.getUuid(),
@@ -918,13 +918,12 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
 
     public void uploadFileForLogRecord(String logRecordId, InputStream fileContent, String fileName) {
         try {
-            String url = String.format(
-                    uploadUrlTemplate,
-                    logRecordId,
-                    URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
-                    "text/html",
-                    URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
-                    "");
+            String url = uploadUrlTemplate.formatted(
+                logRecordId,
+                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+                "text/html",
+                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+                "");
             UploadScreenshotResponse response = requestUtils.postRequestStream(
                     url, fileContent, UploadScreenshotResponse.class);
             log.debug("File '{}' was uploaded for Log Record {}. Response {}", fileName, logRecordId, response);
@@ -942,13 +941,12 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         String contentType = (String) attribute.get(RamConstants.SCREENSHOT_TYPE_KEY);
         String snapshotSource = (String) attribute.get(RamConstants.SCREENSHOT_SOURCE_KEY);
         String snapshotExternalSource = (String) attribute.get(RamConstants.SCREENSHOT_EXTERNAL_SOURCE_KEY);
-        return String.format(
-                uploadUrlTemplate,
-                message.getUuid(),
-                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
-                contentType,
-                URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), RamConstants.UTF8_CHARSET),
-                URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""), RamConstants.UTF8_CHARSET));
+        return uploadUrlTemplate.formatted(
+            message.getUuid(),
+            URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+            contentType,
+            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), RamConstants.UTF8_CHARSET),
+            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""), RamConstants.UTF8_CHARSET));
     }
 
     /**

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AbstractAdapter.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -920,9 +921,9 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         try {
             String url = uploadUrlTemplate.formatted(
                 logRecordId,
-                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+                URLEncoder.encode(fileName, StandardCharsets.UTF_8),
                 "text/html",
-                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+                URLEncoder.encode(fileName, StandardCharsets.UTF_8),
                 "");
             UploadScreenshotResponse response = requestUtils.postRequestStream(
                     url, fileContent, UploadScreenshotResponse.class);
@@ -943,10 +944,10 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
         String snapshotExternalSource = (String) attribute.get(RamConstants.SCREENSHOT_EXTERNAL_SOURCE_KEY);
         return uploadUrlTemplate.formatted(
             message.getUuid(),
-            URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+            URLEncoder.encode(fileName, StandardCharsets.UTF_8),
             contentType,
-            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), RamConstants.UTF8_CHARSET),
-            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""), RamConstants.UTF8_CHARSET));
+            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), StandardCharsets.UTF_8),
+            URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""), StandardCharsets.UTF_8));
     }
 
     /**
@@ -955,7 +956,7 @@ public abstract class AbstractAdapter implements AtpRamAdapter {
      * @param message Message with attributes.
      */
     protected void uploadFirstFile(Message message) {
-        Map<String, Object> attributes = message.getAttributes().get(0);
+        Map<String, Object> attributes = message.getAttributes().getFirst();
         UploadScreenshotResponse response = uploadFile(attributes, message);
 
         String contentType = (String) attributes.get(RamConstants.SCREENSHOT_TYPE_KEY);

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapter.java
@@ -18,6 +18,7 @@ package org.qubership.atp.adapter.common.adapters;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -378,9 +379,9 @@ public class AtpImporterRamAdapter extends AbstractAdapter {
         return uploadUrlTemplate.formatted(
             message.getUuid(),
             context.getProjectId(),
-            URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+            URLEncoder.encode(fileName, StandardCharsets.UTF_8),
             contentType,
-            URLEncoder.encode(StringUtils.defaultIfEmpty(attachmentSource, ""), RamConstants.UTF8_CHARSET));
+            URLEncoder.encode(StringUtils.defaultIfEmpty(attachmentSource, ""), StandardCharsets.UTF_8));
     }
 
     @Override

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapter.java
@@ -176,7 +176,7 @@ public class AtpImporterRamAdapter extends AbstractAdapter {
         } catch (Exception ioException) { //Here IOException can be thrown which is hidden.
             log.error("Failed to create TR for ER {}", request.getAtpExecutionRequestId(), ioException);
             throw new FailedToCreateRamEntity(
-                    String.format("Failed to create TR for ER %s", request.getAtpExecutionRequestId()),
+                "Failed to create TR for ER %s".formatted(request.getAtpExecutionRequestId()),
                     ioException);
         }
     }
@@ -375,13 +375,12 @@ public class AtpImporterRamAdapter extends AbstractAdapter {
         String fileName = (String) attribute.get(RamConstants.SCREENSHOT_NAME_KEY);
         String contentType = (String) attribute.get(RamConstants.SCREENSHOT_TYPE_KEY);
         String attachmentSource = (String) attribute.get(RamConstants.SCREENSHOT_SOURCE_KEY);
-        return String.format(
-                uploadUrlTemplate,
-                message.getUuid(),
-                context.getProjectId(),
-                URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
-                contentType,
-                URLEncoder.encode(StringUtils.defaultIfEmpty(attachmentSource, ""), RamConstants.UTF8_CHARSET));
+        return uploadUrlTemplate.formatted(
+            message.getUuid(),
+            context.getProjectId(),
+            URLEncoder.encode(fileName, RamConstants.UTF8_CHARSET),
+            contentType,
+            URLEncoder.encode(StringUtils.defaultIfEmpty(attachmentSource, ""), RamConstants.UTF8_CHARSET));
     }
 
     @Override

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpReceiverRamAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpReceiverRamAdapter.java
@@ -52,6 +52,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,8 +63,8 @@ import java.util.concurrent.Executors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.http.client.fluent.Content;
-import org.apache.http.client.fluent.Request;
+import org.apache.hc.client5.http.fluent.Content;
+import org.apache.hc.client5.http.fluent.Request;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.context.TestRunContext;
 import org.qubership.atp.adapter.common.context.TestRunContextHolder;
@@ -298,14 +299,14 @@ public class AtpReceiverRamAdapter extends AbstractAdapter {
         String output;
         try {
             final Content postResult = RequestUtils.getHttpExecutor()
-                    .execute(Request.Post(atpRamUrl + "/api/mail/send/er/report")
+                    .execute(Request.post(atpRamUrl + "/api/mail/send/er/report")
                             .bodyString(params.toString(), ContentType.APPLICATION_JSON)).returnContent();
             output = postResult.asString();
             if (log.isDebugEnabled()) {
                 log.debug("Send report response: " + output);
             }
             final Content getResult = RequestUtils.getHttpExecutor()
-                    .execute(Request.Get(atpLoggerUrl + "/er/" + executionRequestUuid + "/stop")).returnContent();
+                    .execute(Request.get(atpLoggerUrl + "/er/" + executionRequestUuid + "/stop")).returnContent();
             output = getResult.asString();
             if (log.isDebugEnabled()) {
                 log.debug("Stop ER response: " + output);
@@ -364,7 +365,7 @@ public class AtpReceiverRamAdapter extends AbstractAdapter {
         ObjectNode result = OBJECT_MAPPER.createObjectNode();
         try {
             final Content postResult = RequestUtils.getHttpExecutor()
-                    .execute(Request.Post(url)
+                    .execute(Request.post(url)
                             .bodyString(request, ContentType.APPLICATION_JSON)).returnContent();
             String output = postResult.asString();
             if (log.isDebugEnabled()) {
@@ -386,11 +387,13 @@ public class AtpReceiverRamAdapter extends AbstractAdapter {
         Runnable task = () -> {
             try (InputStream stream = new FileInputStream(file)) {
                 final Content postResult = RequestUtils.getHttpExecutor()
-                        .execute(Request.Post(atpLoggerUrl + "/lr/upload/" + uuid + "/stream?fileName="
+                        .execute(Request.post(atpLoggerUrl + "/lr/upload/" + uuid + "/stream?fileName="
                                 + fileName + "&contentType=" + contentType + "&snapshotSource="
-                                + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), "UTF-8")
+                                + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""),
+                                        StandardCharsets.UTF_8)
                                 + "&snapshotExternalSource=" + URLEncoder.encode(
-                                StringUtils.defaultIfEmpty(snapshotExternalSource, ""), "UTF-8"))
+                                StringUtils.defaultIfEmpty(snapshotExternalSource, ""),
+                                        StandardCharsets.UTF_8))
                                 .bodyStream(stream, ContentType.APPLICATION_JSON)).returnContent();
                 String output = postResult.asString();
                 log.debug("GridFS FileId: {} ", output);

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpReceiverRamAdapter.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/AtpReceiverRamAdapter.java
@@ -61,9 +61,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.http.client.fluent.Content;
 import org.apache.http.client.fluent.Request;
-import org.apache.http.entity.ContentType;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.context.TestRunContext;
 import org.qubership.atp.adapter.common.context.TestRunContextHolder;

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/interceptors/MdcHttpRequestInterceptor.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/interceptors/MdcHttpRequestInterceptor.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.slf4j.MDC;
@@ -35,10 +36,10 @@ public class MdcHttpRequestInterceptor implements HttpRequestInterceptor {
     }
 
     @Override
-    public void process(ClassicHttpRequest request, HttpContext context) {
+    public void process(HttpRequest httpRequest, EntityDetails entityDetails, HttpContext httpContext) {
         businessIds.forEach(idName -> {
             if (MDC.get(idName) != null) {
-                request.addHeader(convertIdNameToHeader(idName), MDC.get(idName));
+                httpRequest.addHeader(convertIdNameToHeader(idName), MDC.get(idName));
             }
         });
     }

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/interceptors/MdcHttpRequestInterceptor.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/adapters/interceptors/MdcHttpRequestInterceptor.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.slf4j.MDC;
 
 public class MdcHttpRequestInterceptor implements HttpRequestInterceptor {
@@ -35,7 +35,7 @@ public class MdcHttpRequestInterceptor implements HttpRequestInterceptor {
     }
 
     @Override
-    public void process(HttpRequest request, HttpContext context) {
+    public void process(ClassicHttpRequest request, HttpContext context) {
         businessIds.forEach(idName -> {
             if (MDC.get(idName) != null) {
                 request.addHeader(convertIdNameToHeader(idName), MDC.get(idName));

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/kafka/client/KafkaAdminClientService.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/kafka/client/KafkaAdminClientService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
-
 import org.qubership.atp.adapter.common.kafka.error.AtpKafkaAdminClientException;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -67,7 +67,7 @@ public class KafkaAdminClientService {
             Set<String> existingTopics = getTopicNames().get();
             return existingTopics.contains(topicName);
         } catch (InterruptedException | ExecutionException exc) {
-            String message = String.format(KAFKA_TOPIC_EXISTENCE_CHECK_ERROR_MESSAGE_TEMPLATE, topicName);
+            String message = KAFKA_TOPIC_EXISTENCE_CHECK_ERROR_MESSAGE_TEMPLATE.formatted(topicName);
             log.error(message, exc);
             throw new AtpKafkaAdminClientException(exc, message);
         }
@@ -86,7 +86,7 @@ public class KafkaAdminClientService {
                     .all();
             future.get();
         } catch (InterruptedException | ExecutionException exc) {
-            String message = String.format(KAFKA_TOPIC_CREATION_ERROR_MESSAGE_TEMPLATE, topicName);
+            String message = KAFKA_TOPIC_CREATION_ERROR_MESSAGE_TEMPLATE.formatted(topicName);
             log.error(message, exc);
             throw new AtpKafkaAdminClientException(exc, message);
         }
@@ -103,7 +103,7 @@ public class KafkaAdminClientService {
             Map<String, TopicDescription> topicDescription = topicDescriptionFuture.get();
             return topicDescription.get(topicName);
         } catch (InterruptedException | ExecutionException exc) {
-            String message = String.format(KAFKA_TOPIC_DESCRIPTION_ERROR_MESSAGE_TEMPLATE, topicName);
+            String message = KAFKA_TOPIC_DESCRIPTION_ERROR_MESSAGE_TEMPLATE.formatted(topicName);
             log.error(message, exc);
             throw new AtpKafkaAdminClientException(exc, message);
         }
@@ -118,7 +118,7 @@ public class KafkaAdminClientService {
         try {
             future.get();
         } catch (InterruptedException | ExecutionException exc) {
-            String message = String.format(KAFKA_TOPIC_DELETE_ERROR_MESSAGE_TEMPLATE, topicName);
+            String message = KAFKA_TOPIC_DELETE_ERROR_MESSAGE_TEMPLATE.formatted(topicName);
             log.error(message, exc);
             throw new AtpKafkaAdminClientException(exc, message);
         }
@@ -135,7 +135,7 @@ public class KafkaAdminClientService {
             KafkaFuture<Void> future = client.createPartitions(newPartitionSet).all();
             future.get();
         } catch (InterruptedException | ExecutionException exc) {
-            String message = String.format(KAFKA_TOPIC_INCREASE_PARTITIONS_ERROR_MESSAGE_TEMPLATE, topicName);
+            String message = KAFKA_TOPIC_INCREASE_PARTITIONS_ERROR_MESSAGE_TEMPLATE.formatted(topicName);
             log.error(message, exc);
             throw new AtpKafkaAdminClientException(exc, message);
         }

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/Config.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/Config.java
@@ -21,7 +21,7 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
@@ -49,7 +49,7 @@ public class Config {
     }
 
     private void loadConfigFiles() {
-        File dir = new File(Paths.get("").toAbsolutePath().toString());
+        File dir = new File(Path.of("").toAbsolutePath().toString());
         FileFilter fileFilter = new WildcardFileFilter("*.properties");
         configs = dir.listFiles(fileFilter);
     }

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/HttpClientBuilderProvider.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/HttpClientBuilderProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.qubership.atp.adapter.common.utils;
 
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 
 @FunctionalInterface
 public interface HttpClientBuilderProvider {

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/RequestUtils.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/RequestUtils.java
@@ -39,19 +39,19 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.client.fluent.Content;
-import org.apache.http.client.fluent.Request;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
-import org.apache.http.ssl.SSLContexts;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.client.fluent.Content;
+import org.apache.hc.core5.http.client.fluent.Request;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.interceptors.MdcHttpRequestInterceptor;
 import org.qubership.atp.adapter.common.entities.Message;
@@ -358,7 +358,7 @@ public class RequestUtils {
      *
      * @return Executor
      */
-    public static org.apache.http.client.fluent.Executor getHttpExecutor() {
+    public static org.apache.hc.core5.http.client.fluent.Executor getHttpExecutor() {
         HttpClientBuilder httpClientBuilder = Optional.ofNullable(httpClientBuilderProvider)
                 .map(HttpClientBuilderProvider::getBuilder)
                 .orElseGet(HttpClientBuilder::create);
@@ -382,7 +382,7 @@ public class RequestUtils {
         for (HttpRequestInterceptor interceptor : interceptors) {
             httpClientBuilder.addInterceptorLast(interceptor);
         }
-        return org.apache.http.client.fluent.Executor.newInstance(httpClientBuilder.build());
+        return org.apache.hc.core5.http.client.fluent.Executor.newInstance(httpClientBuilder.build());
     }
 
     /**

--- a/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/RequestUtils.java
+++ b/qubership-atp-adapter-common/src/main/java/org/qubership/atp/adapter/common/utils/RequestUtils.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,18 +40,16 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.fluent.Content;
+import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
-import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
-import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
-import org.apache.hc.core5.http.client.fluent.Content;
-import org.apache.hc.core5.http.client.fluent.Request;
-import org.apache.hc.core5.http.config.Registry;
-import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.interceptors.MdcHttpRequestInterceptor;
@@ -133,8 +132,8 @@ public class RequestUtils {
             String url,
             Object request,
             Class<ResponseTypeT> responseType) throws IOException {
-        return request != null ? requestWithBody(url, request, responseType, Request::Post) :
-                requestWithoutBody(url, responseType, Request::Post);
+        return request != null ? requestWithBody(url, request, responseType, Request::post) :
+                requestWithoutBody(url, responseType, Request::post);
     }
 
     /**
@@ -152,8 +151,8 @@ public class RequestUtils {
             String url,
             Object request,
             Class<ResponseTypeT> responseType) throws IOException {
-        return request != null ? requestWithBody(url, request, responseType, Request::Put) :
-                requestWithoutBody(url, responseType, Request::Put);
+        return request != null ? requestWithBody(url, request, responseType, Request::put) :
+                requestWithoutBody(url, responseType, Request::put);
     }
 
     /**
@@ -171,8 +170,8 @@ public class RequestUtils {
             String url,
             Object request,
             Class<ResponseTypeT> responseType) throws IOException {
-        return request != null ? requestWithBody(url, request, responseType, Request::Patch) :
-                requestWithoutBody(url, responseType, Request::Patch);
+        return request != null ? requestWithBody(url, request, responseType, Request::patch) :
+                requestWithoutBody(url, responseType, Request::patch);
     }
 
     /**
@@ -190,7 +189,7 @@ public class RequestUtils {
             String url,
             InputStream requestStream,
             Class<ResponseTypeT> responseType) throws IOException {
-        return requestWithBodyStream(url, Objects.requireNonNull(requestStream), responseType, Request::Post);
+        return requestWithBodyStream(url, Objects.requireNonNull(requestStream), responseType, Request::post);
     }
 
     private static <ResponseTypeT> ResponseTypeT requestWithBody(
@@ -249,7 +248,7 @@ public class RequestUtils {
         String result = "";
         try {
             final Content postResult = getHttpExecutor()
-                    .execute(Request.Post(url)
+                    .execute(Request.post(url)
                             .bodyString(request, ContentType.APPLICATION_JSON)).returnContent();
             if (postResult.equals(Content.NO_CONTENT)) {
                 return null;
@@ -268,7 +267,7 @@ public class RequestUtils {
         try {
             return OBJECT_MAPPER.readValue(
                     getHttpExecutor()
-                            .execute(Request.Put(url))
+                            .execute(Request.put(url))
                             .returnContent()
                             .asString(), ObjectNode.class);
         } catch (IOException e) {
@@ -281,7 +280,7 @@ public class RequestUtils {
         try {
             OBJECT_MAPPER.readValue(
                     getHttpExecutor()
-                            .execute(Request.Put(url).bodyString(request, ContentType.APPLICATION_JSON))
+                            .execute(Request.put(url).bodyString(request, ContentType.APPLICATION_JSON))
                             .returnContent()
                             .asString(), ObjectNode.class);
         } catch (IOException e) {
@@ -293,7 +292,7 @@ public class RequestUtils {
         try {
             return OBJECT_MAPPER.readValue(
                     getHttpExecutor()
-                            .execute(Request.Get(url))
+                            .execute(Request.get(url))
                             .returnContent()
                             .asString(), ObjectNode.class);
         } catch (IOException e) {
@@ -331,11 +330,13 @@ public class RequestUtils {
         final Content postResult;
         try {
             postResult = getHttpExecutor()
-                    .execute(Request.Post(url + "/?fileName=" + fileName + "&contentType=" + contentType
+                    .execute(Request.post(url + "/?fileName=" + fileName + "&contentType=" + contentType
                                     + "&snapshotSource="
-                                    + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""), "UTF-8")
+                                    + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotSource, ""),
+                                    StandardCharsets.UTF_8)
                                     + "&snapshotExternalSource="
-                                    + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""), "UTF-8")
+                                    + URLEncoder.encode(StringUtils.defaultIfEmpty(snapshotExternalSource, ""),
+                                    StandardCharsets.UTF_8)
                             ).bodyStream(stream, ContentType.APPLICATION_OCTET_STREAM)).returnContent();
             output = OBJECT_MAPPER.readValue(postResult.asString(), UploadScreenshotResponse.class);
             log.debug("Url: {}, RAM response: {} ", url, output);
@@ -358,31 +359,38 @@ public class RequestUtils {
      *
      * @return Executor
      */
-    public static org.apache.hc.core5.http.client.fluent.Executor getHttpExecutor() {
+    public static org.apache.hc.client5.http.fluent.Executor getHttpExecutor() {
         HttpClientBuilder httpClientBuilder = Optional.ofNullable(httpClientBuilderProvider)
                 .map(HttpClientBuilderProvider::getBuilder)
                 .orElseGet(HttpClientBuilder::create);
         try {
-            SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, (cert, authType) -> true).build();
-            SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext,
-                    NoopHostnameVerifier.INSTANCE);
-            Registry<ConnectionSocketFactory> socketFactoryRegistry =
-                    RegistryBuilder.<ConnectionSocketFactory>create()
-                            .register(HTTPS, sslsf)
-                            .register(HTTP, new PlainConnectionSocketFactory())
+            // 1. Create SSLContext which trusts all certificates
+            SSLContext sslContext = SSLContexts.custom()
+                    .loadTrustMaterial(null, (cert, authType) -> true)
+                    .build();
+
+            // 2. Create TlsStrategy with this SSLContext and hostname verifying turned OFF.
+            TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
+                    sslContext,
+                    NoopHostnameVerifier.INSTANCE
+            );
+
+            // 3. Create ConnectionManager
+            PoolingHttpClientConnectionManager connectionManager =
+                    PoolingHttpClientConnectionManagerBuilder.create()
+                            .setTlsSocketStrategy(tlsStrategy)
                             .build();
 
-            BasicHttpClientConnectionManager connectionManager =
-                    new BasicHttpClientConnectionManager(socketFactoryRegistry);
-            httpClientBuilder.setSSLSocketFactory(sslsf).setConnectionManager(connectionManager);
+            // 4. Set ConnectionManager in the builder
+            httpClientBuilder.setConnectionManager(connectionManager);
         } catch (GeneralSecurityException exception) {
             log.error("An error occurred while creating the SSLContext for http executor.", exception);
         }
-        httpClientBuilder.addInterceptorFirst(new MdcHttpRequestInterceptor(businessIds));
+        httpClientBuilder.addRequestInterceptorFirst(new MdcHttpRequestInterceptor(businessIds));
         for (HttpRequestInterceptor interceptor : interceptors) {
-            httpClientBuilder.addInterceptorLast(interceptor);
+            httpClientBuilder.addRequestInterceptorLast(interceptor);
         }
-        return org.apache.hc.core5.http.client.fluent.Executor.newInstance(httpClientBuilder.build());
+        return org.apache.hc.client5.http.fluent.Executor.newInstance(httpClientBuilder.build());
     }
 
     /**
@@ -394,7 +402,7 @@ public class RequestUtils {
      */
     @Deprecated
     public static void uploadOneFile(Message message, String atpRamUrl) {
-        Map attributes = message.getAttributes().get(0);
+        Map attributes = message.getAttributes().getFirst();
         UploadScreenshotResponse response = uploadFile(attributes, message.getUuid(), atpRamUrl);
 
         String contentType = (String) attributes.get(RamConstants.SCREENSHOT_TYPE_KEY);

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AbstractAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AbstractAdapterTest.java
@@ -19,6 +19,7 @@ package org.qubership.atp.adapter.common.adapters;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -161,8 +162,7 @@ public class AbstractAdapterTest {
     }
 
     @Test
-    public void startExecutionRequest_FailedToCreateEntityIsThrownInCaseOfBadResponse() throws
-            IOException {
+    public void startExecutionRequest_FailedToCreateEntityIsThrownInCaseOfBadResponse() {
       assertThrows(FailedToCreateRamEntity.class, () -> {
         ExecutionRequest createdRequest = createExecutionRequest();
         when(requestUtils.postRequest(any(String.class), any(ExecutionRequest.class), any()))
@@ -294,7 +294,7 @@ public class AbstractAdapterTest {
     }
 
     @Test
-    public void reportDetails_FailedToCreateRamEntityIsThrownInCaseOfRamResponseError() throws IOException {
+    public void reportDetails_FailedToCreateRamEntityIsThrownInCaseOfRamResponseError() {
       assertThrows(FailedToCreateRamEntity.class, () -> {
         when(requestUtils.postRequest(any(String.class), any(), any()))
             .thenThrow(new IOException("RAM error"));
@@ -433,7 +433,7 @@ public class AbstractAdapterTest {
     public void createBvLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.BV.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof BvLogRecord);
+        assertInstanceOf(BvLogRecord.class, logRecord);
     }
 
     @Test
@@ -441,56 +441,56 @@ public class AbstractAdapterTest {
         Message message = ModelMocks.generateMessage(TypeAction.MIA.toString());
         message.setIsGroup(true);
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof MiaLogRecord);
+        assertInstanceOf(MiaLogRecord.class, logRecord);
     }
 
     @Test
     public void createUiLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.UI.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof UiLogRecord);
+        assertInstanceOf(UiLogRecord.class, logRecord);
     }
 
     @Test
     public void createItfLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.ITF.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        assertTrue(logRecord instanceof ItfLogRecord);
+        assertInstanceOf(ItfLogRecord.class, logRecord);
     }
 
     @Test
     public void createRestLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.REST.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof RestLogRecord);
+        assertInstanceOf(RestLogRecord.class, logRecord);
     }
 
     @Test
     public void createSqlLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.SQL.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof SqlLogRecord);
+        assertInstanceOf(SqlLogRecord.class, logRecord);
     }
 
     @Test
     public void createSshLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.SSH.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof SshLogRecord);
+        assertInstanceOf(SshLogRecord.class, logRecord);
     }
 
     @Test
     public void createCompoundLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.COMPOUND.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        assertTrue(logRecord instanceof CompoundLogRecord);
+        assertInstanceOf(CompoundLogRecord.class, logRecord);
     }
 
     @Test
     public void createTechnicalLogRecordTest() {
         Message message = ModelMocks.generateMessage(TypeAction.TECHNICAL.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue(logRecord instanceof TechnicalLogRecord);
+        assertInstanceOf(TechnicalLogRecord.class, logRecord);
 
     }
 
@@ -558,7 +558,7 @@ public class AbstractAdapterTest {
         List<CustomLink> resCustomLinks = logRecord.getCustomLinks();
         assertNotNull(resCustomLinks);
         Assertions.assertEquals(2, resCustomLinks.size());
-        CustomLink customLink = resCustomLinks.get(0);
+        CustomLink customLink = resCustomLinks.getFirst();
         Assertions.assertEquals("name1", customLink.getName());
         Assertions.assertEquals("http://url1", customLink.getUrl());
         Assertions.assertEquals(OpenMode.NEW_TAB, customLink.getOpenMode());

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AbstractAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AbstractAdapterTest.java
@@ -17,13 +17,14 @@
 package org.qubership.atp.adapter.common.adapters;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,10 +49,10 @@ import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.qubership.atp.adapter.common.RamConstants;
@@ -102,7 +103,7 @@ public class AbstractAdapterTest {
             new ContextVariable("test", "beforeValue", "afterValue"));
     private RequestUtils requestUtils;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         abstractAdapter = Mockito.mock(AbstractAdapter.class, Mockito.CALLS_REAL_METHODS);
         TestRunContext context = new TestRunContext();
@@ -128,8 +129,7 @@ public class AbstractAdapterTest {
                 .postRequest(
                         argThat(url -> url.contains(CREATE_ER_PATH)),
                         argThat(er -> {
-                            if (er instanceof ExecutionRequest) {
-                                ExecutionRequest erToCreate = (ExecutionRequest) er;
+                            if (er instanceof ExecutionRequest erToCreate) {
                                 return erToCreate.getName().equals(createdRequest.getName()) &&
                                         erToCreate.getTestPlanId().equals(createdRequest.getTestPlanId()) &&
                                         erToCreate.getProjectId().equals(createdRequest.getProjectId()) &&
@@ -152,25 +152,27 @@ public class AbstractAdapterTest {
                 createdRequest.getProjectId(),
                 createdRequest.getTestPlanId(),
                 createdRequest.getExecutionStatus());
-        assertEquals("ER id should be filled in context",
-                createdRequest.getUuid().toString(), resultContext.getExecutionRequestId());
-        assertEquals("Project id should be filled in context",
-                createdRequest.getProjectId().toString(), resultContext.getProjectId());
-        assertEquals("Test plan id should be filled in context",
-                createdRequest.getTestPlanId().toString(), resultContext.getTestPlanId());
+        assertEquals(createdRequest.getUuid().toString(),
+                resultContext.getExecutionRequestId(), "ER id should be filled in context");
+        assertEquals(createdRequest.getProjectId().toString(),
+                resultContext.getProjectId(), "Project id should be filled in context");
+        assertEquals(createdRequest.getTestPlanId().toString(),
+                resultContext.getTestPlanId(), "Test plan id should be filled in context");
     }
 
-    @Test(expected = FailedToCreateRamEntity.class)
-    public void startExecutionRequest_FailedToCreateEntityIsThrownInCaseOfBadResponse() throws FailedToCreateRamEntity,
+    @Test
+    public void startExecutionRequest_FailedToCreateEntityIsThrownInCaseOfBadResponse() throws
             IOException {
+      assertThrows(FailedToCreateRamEntity.class, () -> {
         ExecutionRequest createdRequest = createExecutionRequest();
         when(requestUtils.postRequest(any(String.class), any(ExecutionRequest.class), any()))
-                .thenThrow(new IOException("Ram error"));
+            .thenThrow(new IOException("Ram error"));
         abstractAdapter.startExecutionRequest(
-                createdRequest.getName(),
-                createdRequest.getProjectId(),
-                createdRequest.getTestPlanId(),
-                createdRequest.getExecutionStatus());
+            createdRequest.getName(),
+            createdRequest.getProjectId(),
+            createdRequest.getTestPlanId(),
+            createdRequest.getExecutionStatus());
+      });
     }
 
     @Test
@@ -186,7 +188,7 @@ public class AbstractAdapterTest {
                         any());
     }
 
-    @Test()
+    @Test
     public void updateTestRun_DetailsReportIsSentInCaseOfPatchError() throws IOException,
             FailedToCreateRamEntity {
         TestRun testRunPatch = new TestRun();
@@ -201,7 +203,7 @@ public class AbstractAdapterTest {
                 .reportDetails(any(String.class), eq(TestingStatuses.FAILED));
     }
 
-    @Test()
+    @Test
     public void finishAllTestRuns_ifDelayedProperEndpointIsInvoked() throws IOException,
             FailedToCreateRamEntity {
         List<UUID> uuids = asList(UUID.randomUUID(), UUID.randomUUID());
@@ -221,7 +223,7 @@ public class AbstractAdapterTest {
         );
     }
 
-    @Test()
+    @Test
     public void finishAllTestRuns_ifNotDelayedProperEndpointIsInvoked() throws IOException,
             FailedToCreateRamEntity {
         List<UUID> uuids = asList(UUID.randomUUID(), UUID.randomUUID());
@@ -230,14 +232,14 @@ public class AbstractAdapterTest {
         abstractAdapter.finishAllTestRuns(uuids, false);
         for (UUID uuid : uuids) {
             verify(requestUtils, times(1)).putRequest(
-                    argThat(url -> url.contains(String.format(FINISH_TR_PATH_TEMPLATE, uuid))),
+                    argThat(url -> url.contains(FINISH_TR_PATH_TEMPLATE.formatted(uuid))),
                     eq(null),
                     any()
             );
         }
     }
 
-    @Test()
+    @Test
     public void finishAllTestRuns_DetailsReportIsSentInCaseOfFinishError() throws IOException,
             FailedToCreateRamEntity {
         List<UUID> uuids = asList(UUID.randomUUID(), UUID.randomUUID());
@@ -252,7 +254,7 @@ public class AbstractAdapterTest {
                 .reportDetails(any(String.class), eq(TestingStatuses.FAILED));
     }
 
-    @Test()
+    @Test
     public void reportDetails_reportDetailsEndpointIsInvokedProperly() throws IOException,
             FailedToCreateRamEntity {
         when(requestUtils.postRequest(any(String.class), any(), any()))
@@ -264,10 +266,9 @@ public class AbstractAdapterTest {
         abstractAdapter.reportDetails(DETAILS_MESSAGE, TestingStatuses.FAILED);
         verify(requestUtils, times(1))
                 .postRequest(
-                        argThat(url -> url.contains(String.format(API_ER_DETAILS_TEMPLATE, erId))),
+                        argThat(url -> url.contains(API_ER_DETAILS_TEMPLATE.formatted(erId))),
                         argThat(details -> {
-                            if (details instanceof ExecutionRequestDetails) {
-                                ExecutionRequestDetails requestDetails = (ExecutionRequestDetails) details;
+                            if (details instanceof ExecutionRequestDetails requestDetails) {
                                 return requestDetails.getMessage().equals(DETAILS_MESSAGE) &&
                                         requestDetails.getStatus().equals(TestingStatuses.FAILED) &&
                                         requestDetails.getExecutionRequestId().equals(erId) &&
@@ -279,7 +280,7 @@ public class AbstractAdapterTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void stopAtpRun_WithEmptyFields_CreateRequestWithoutErrors() throws IOException {
         String trId = abstractAdapter.getContext().getTestRunId();
         ObjectNode expectedRequest = OBJECT_MAPPER.createObjectNode();
@@ -292,16 +293,17 @@ public class AbstractAdapterTest {
         verify(requestUtils, times(1)).postRequest(any(), eq(expectedRequest.toString()), any());
     }
 
-    @Test(expected = FailedToCreateRamEntity.class)
-    public void reportDetails_FailedToCreateRamEntityIsThrownInCaseOfRamResponseError() throws IOException,
-            FailedToCreateRamEntity {
+    @Test
+    public void reportDetails_FailedToCreateRamEntityIsThrownInCaseOfRamResponseError() throws IOException {
+      assertThrows(FailedToCreateRamEntity.class, () -> {
         when(requestUtils.postRequest(any(String.class), any(), any()))
-                .thenThrow(new IOException("RAM error"));
+            .thenThrow(new IOException("RAM error"));
         UUID erId = UUID.randomUUID();
         UUID projectId = UUID.randomUUID();
         abstractAdapter.getContext().setExecutionRequestId(erId.toString());
         abstractAdapter.getContext().setProjectId(projectId.toString());
         abstractAdapter.reportDetails(DETAILS_MESSAGE, TestingStatuses.FAILED);
+      });
     }
 
     @Test
@@ -375,8 +377,8 @@ public class AbstractAdapterTest {
         when(requestUtils.postRequestStream(any(String.class), any(), any()))
                 .thenReturn(expectedResponse);
         UploadScreenshotResponse actualResponse = abstractAdapter.uploadFile(attributes, message);
-        assertEquals("UploadScreenshotResponse should be returned from RAM",
-                expectedResponse, actualResponse);
+        assertEquals(expectedResponse,
+                actualResponse, "UploadScreenshotResponse should be returned from RAM");
     }
 
     private Map<String, Object> createAttributes(InputStream streamToUpload) {
@@ -400,14 +402,14 @@ public class AbstractAdapterTest {
     public void createLogRecord_SetEmptyTypeAction_GenerateValidLogRecord() {
         Message message = ModelMocks.generateMessage(StringUtils.EMPTY);
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        Assert.assertEquals("Type action is default value (TECHNICAL)", TypeAction.TECHNICAL, logRecord.getType());
+        Assertions.assertEquals(TypeAction.TECHNICAL, logRecord.getType(), "Type action is default value (TECHNICAL)");
     }
 
     @Test
     public void createLogRecord_SetNotEmptyTypeAction_GenerateValidLogRecord() {
         Message message = ModelMocks.generateMessage(TypeAction.BV.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        Assert.assertEquals("Type action is BV", TypeAction.BV, logRecord.getType());
+        Assertions.assertEquals(TypeAction.BV, logRecord.getType(), "Type action is BV");
     }
 
     @Test
@@ -415,7 +417,7 @@ public class AbstractAdapterTest {
         Message message = ModelMocks.generateMessage(TypeAction.BV.toString());
         message.setUuid("null");
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        assertTrue("ID of LogRecord should be filled", Objects.nonNull(logRecord.getUuid()));
+        assertTrue(Objects.nonNull(logRecord.getUuid()), "ID of LogRecord should be filled");
     }
 
     @Test
@@ -424,7 +426,7 @@ public class AbstractAdapterTest {
         long createdDateStamp = new Random().nextLong();
         message.setCreatedDateStamp(createdDateStamp);
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        Assert.assertEquals("Created Date is set", createdDateStamp, logRecord.getCreatedDateStamp());
+        Assertions.assertEquals(createdDateStamp, logRecord.getCreatedDateStamp(), "Created Date is set");
     }
 
     @Test
@@ -496,23 +498,23 @@ public class AbstractAdapterTest {
     public void createLogRecord_SetParentSectionIdAsNull_GenerateLogRecordWithEmptyParentId() {
         Message message = ModelMocks.generateMessage(TypeAction.BV.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        assertTrue("ID of parent LogRecord should be empty", Objects.isNull(logRecord.getParentRecordId()));
+        assertTrue(Objects.isNull(logRecord.getParentRecordId()), "ID of parent LogRecord should be empty");
     }
 
     @Test
     public void createLogRecord_maskMessageAndTitle_generateEncryptedMessage() {
         Message message = ModelMocks.generateEncryptedMessage(TypeAction.BV.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        assertEquals("Log record title should be masked",
-                MASKED_MESSAGE, logRecord.getName());
-        assertEquals("Log record message should be masked", MASKED_MESSAGE, logRecord.getMessage());
+        assertEquals(MASKED_MESSAGE,
+                logRecord.getName(), "Log record title should be masked");
+        assertEquals(MASKED_MESSAGE, logRecord.getMessage(), "Log record message should be masked");
     }
 
     @Test
     public void createLogRecord_SetMessageFieldInMessage_GenerateLogRecordWithFilledMessage() {
         Message message = ModelMocks.generateMessage(TypeAction.BV.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        Assert.assertEquals("Message of LogRecord should be filled", message.getMessage(), logRecord.getMessage());
+        Assertions.assertEquals(message.getMessage(), logRecord.getMessage(), "Message of LogRecord should be filled");
     }
 
     @Test
@@ -521,8 +523,8 @@ public class AbstractAdapterTest {
         String expectedStatus = TestingStatuses.FAILED.toString();
         message.setTestingStatus(expectedStatus.toUpperCase());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        Assert.assertEquals("Log record should keep status through conversion", expectedStatus,
-                logRecord.getTestingStatus().toString());
+        Assertions.assertEquals(expectedStatus, logRecord.getTestingStatus().toString(),
+                "Log record should keep status through conversion");
     }
 
     @Test
@@ -531,8 +533,8 @@ public class AbstractAdapterTest {
         String expectedStatus = TestingStatuses.NOT_STARTED.toString();
         message.setTestingStatus(expectedStatus);
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        Assert.assertEquals("Log record should keep status through conversion", expectedStatus,
-                logRecord.getTestingStatus().toString());
+        Assertions.assertEquals(expectedStatus, logRecord.getTestingStatus().toString(),
+                "Log record should keep status through conversion");
     }
 
     @Test
@@ -540,8 +542,8 @@ public class AbstractAdapterTest {
         Message message = ModelMocks.generateMessage(StringUtils.EMPTY);
         message.setStepContextVariables(contextVariables);
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        Assert.assertEquals("Log record should keep step context variables through conversion", contextVariables,
-                logRecord.getStepContextVariables());
+        Assertions.assertEquals(contextVariables, logRecord.getStepContextVariables(),
+                "Log record should keep step context variables through conversion");
     }
 
     @Test
@@ -555,15 +557,15 @@ public class AbstractAdapterTest {
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
         List<CustomLink> resCustomLinks = logRecord.getCustomLinks();
         assertNotNull(resCustomLinks);
-        Assert.assertEquals(2, resCustomLinks.size());
+        Assertions.assertEquals(2, resCustomLinks.size());
         CustomLink customLink = resCustomLinks.get(0);
-        Assert.assertEquals("name1", customLink.getName());
-        Assert.assertEquals("http://url1", customLink.getUrl());
-        Assert.assertEquals(OpenMode.NEW_TAB, customLink.getOpenMode());
+        Assertions.assertEquals("name1", customLink.getName());
+        Assertions.assertEquals("http://url1", customLink.getUrl());
+        Assertions.assertEquals(OpenMode.NEW_TAB, customLink.getOpenMode());
         customLink = resCustomLinks.get(1);
-        Assert.assertEquals("name2", customLink.getName());
-        Assert.assertEquals("http://url2", customLink.getUrl());
-        Assert.assertEquals(OpenMode.CURRENT_TAB, customLink.getOpenMode());
+        Assertions.assertEquals("name2", customLink.getName());
+        Assertions.assertEquals("http://url2", customLink.getUrl());
+        Assertions.assertEquals(OpenMode.CURRENT_TAB, customLink.getOpenMode());
     }
 
     @Test
@@ -571,8 +573,8 @@ public class AbstractAdapterTest {
         LogRecord logRecord = new LogRecord();
         logRecord.setStartDate(new Timestamp(System.currentTimeMillis() - 1));
         abstractAdapter.updateLogRecordDurationAndEndDate(logRecord);
-        Assert.assertNotNull("End date of log record should be filled", logRecord.getEndDate());
-        Assert.assertTrue("Duration of log record should be > 0", logRecord.getDuration() > 0);
+        Assertions.assertNotNull(logRecord.getEndDate(), "End date of log record should be filled");
+        Assertions.assertTrue(logRecord.getDuration() > 0, "Duration of log record should be > 0");
     }
 
     @Test
@@ -584,8 +586,8 @@ public class AbstractAdapterTest {
 
         AtpCompaund result = context.getAtpCompaund();
 
-        Assert.assertEquals(newCompound.getTestingStatuses(), result.getTestingStatuses());
-        Assert.assertEquals(newCompound.getParentSection().getTestingStatuses(),
+        Assertions.assertEquals(newCompound.getTestingStatuses(), result.getTestingStatuses());
+        Assertions.assertEquals(newCompound.getParentSection().getTestingStatuses(),
                 result.getParentSection().getTestingStatuses());
     }
 
@@ -598,8 +600,8 @@ public class AbstractAdapterTest {
 
         AtpCompaund result = context.getAtpCompaund();
 
-        Assert.assertEquals(compoundFromContext.getTestingStatuses(), result.getTestingStatuses());
-        Assert.assertEquals(compoundFromContext.getParentSection().getTestingStatuses(),
+        Assertions.assertEquals(compoundFromContext.getTestingStatuses(), result.getTestingStatuses());
+        Assertions.assertEquals(compoundFromContext.getParentSection().getTestingStatuses(),
                 result.getParentSection().getTestingStatuses());
     }
 
@@ -630,8 +632,8 @@ public class AbstractAdapterTest {
         ExecutionStatuses expectedStatus = ExecutionStatuses.NOT_STARTED;
         message.setTestingStatus(TestingStatuses.NOT_STARTED.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        Assert.assertEquals("Log record should keep status through conversion", expectedStatus,
-                logRecord.getExecutionStatus());
+        Assertions.assertEquals(expectedStatus, logRecord.getExecutionStatus(),
+                "Log record should keep status through conversion");
     }
 
     @Test
@@ -640,8 +642,8 @@ public class AbstractAdapterTest {
         ExecutionStatuses expectedStatus = ExecutionStatuses.FINISHED;
         message.setTestingStatus(TestingStatuses.NOT_STARTED.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, false, false);
-        Assert.assertEquals("Log record should keep status through conversion", expectedStatus,
-                logRecord.getExecutionStatus());
+        Assertions.assertEquals(expectedStatus, logRecord.getExecutionStatus(),
+                "Log record should keep status through conversion");
     }
 
     @Test
@@ -650,8 +652,8 @@ public class AbstractAdapterTest {
         ExecutionStatuses expectedStatus = ExecutionStatuses.IN_PROGRESS;
         message.setTestingStatus(TestingStatuses.UNKNOWN.toString());
         LogRecord logRecord = abstractAdapter.createLogRecord(message, true, false);
-        Assert.assertEquals("Log record should keep status through conversion", expectedStatus,
-                logRecord.getExecutionStatus());
+        Assertions.assertEquals(expectedStatus, logRecord.getExecutionStatus(),
+                "Log record should keep status through conversion");
     }
 
     @Test
@@ -708,9 +710,9 @@ public class AbstractAdapterTest {
         String result = abstractAdapter.getUploadFileUrl(attribute, message);
 
         // Assert
-        assertFalse("Result String with URL contains space ' ' character but should be encoded.",
-                result.contains(" "));
-        assertTrue("Result String with URL doesnt contain correct fileName param",
-                result.contains("fileName=screenshotNameKey+withSpaceCharacter&"));
+        assertFalse(result.contains(" "),
+                "Result String with URL contains space ' ' character but should be encoded.");
+        assertTrue(result.contains("fileName=screenshotNameKey+withSpaceCharacter&"),
+                "Result String with URL doesnt contain correct fileName param");
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package org.qubership.atp.adapter.common.adapters;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -33,17 +34,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.error.FailedToCreateRamEntity;
 import org.qubership.atp.adapter.common.context.TestRunContext;
@@ -69,7 +69,11 @@ import org.qubership.atp.ram.models.logrecords.SshLogRecord;
 import org.qubership.atp.ram.models.logrecords.UiLogRecord;
 import org.qubership.atp.ram.models.logrecords.parts.ContextVariable;
 
-@RunWith(MockitoJUnitRunner.class)
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class AtpImporterRamAdapterTest {
 
     private final TestRunContext testRunContext = new TestRunContext();
@@ -100,7 +104,7 @@ public class AtpImporterRamAdapterTest {
     @Mock
     private BulkLogRecordSender mockBulkLogRecordSender;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testRunContext.setTestRunId(testRunId.toString());
         testRunContext.setProjectId(projectId.toString());
@@ -218,21 +222,23 @@ public class AtpImporterRamAdapterTest {
                 .postRequest(eq(urlToBeInvoked), eq(startRunRequest), eq(StartRunResponse.class));
     }
 
-    @Test(expected = FailedToCreateRamEntity.class)
+    @Test
     public void testStartAtpRun_RamInvocationFails_FailedToCreateRamEntityIsThrown()
             throws IOException {
-        StartRunRequest startRunRequest = StartRunRequest.getRequestBuilder()
-                .setProjectName("Project")
-                .setTestPlanName("Test Plan")
-                .setTestCaseName("TestCase")
-                .setTestRunId(testRunId.toString())
-                .build();
-        StartRunResponse response = new StartRunResponse();
-        response.setTestRunId(UUID.randomUUID());
-        response.setExecutionRequestId(UUID.randomUUID());
-        when(requestUtils.postRequest(any(), any(), any()))
-                .thenThrow(new IOException("Failed to start TR in RAM"));
-        atpImporterRamAdapter.startAtpRun(startRunRequest, atpImporterRamAdapter.context);
+        assertThrows(FailedToCreateRamEntity.class, () -> {
+            StartRunRequest startRunRequest = StartRunRequest.getRequestBuilder()
+                    .setProjectName("Project")
+                    .setTestPlanName("Test Plan")
+                    .setTestCaseName("TestCase")
+                    .setTestRunId(testRunId.toString())
+                    .build();
+            StartRunResponse response = new StartRunResponse();
+            response.setTestRunId(UUID.randomUUID());
+            response.setExecutionRequestId(UUID.randomUUID());
+            when(requestUtils.postRequest(any(), any(), any()))
+                    .thenThrow(new IOException("Failed to start TR in RAM"));
+            atpImporterRamAdapter.startAtpRun(startRunRequest, atpImporterRamAdapter.context);
+        });
     }
 
     @Test
@@ -246,18 +252,14 @@ public class AtpImporterRamAdapterTest {
         ExecutionStatuses newTrStatus = ExecutionStatuses.FINISHED;
         atpImporterRamAdapter.updateTestRunStatus(newTrStatus, trId.toString());
         verify(requestUtils, times(1))
-                .patchRequest(eq(urlToBeInvoked),
-                        argThat(testRunPatch -> {
-                            if (testRunPatch instanceof TestRun) {
-                                TestRun testRun = (TestRun) testRunPatch;
-                                return testRun.getExecutionStatus().equals(newTrStatus)
-                                        && testRun.getUuid().equals(trId)
-                                        && testRun.getTestingStatus() == null;
-                            } else {
-                                return false;
-                            }
-                        }),
-                        eq(null));
+                .patchRequest(eq(urlToBeInvoked), argThat(testRunPatch -> {
+                    if (testRunPatch instanceof TestRun testRun) {
+                        return testRun.getExecutionStatus().equals(newTrStatus)
+                                && testRun.getUuid().equals(trId) && testRun.getTestingStatus() == null;
+                    } else {
+                      return false;
+                    }
+                }), eq(null));
     }
 
     @Test
@@ -277,10 +279,7 @@ public class AtpImporterRamAdapterTest {
                 .postRequest(
                         eq(urlToBeInvoked),
                         argThat(trIds ->
-                                trIds instanceof List
-                                        && ((List<?>) trIds).size() == 2
-                                        && ((List<?>) trIds).contains(trId1)
-                                        && ((List<?>) trIds).contains(trId2)),
+                                trIds instanceof List<?> l && l.size() == 2 && l.contains(trId1) && l.contains(trId2)),
                         eq(null));
     }
 
@@ -401,9 +400,7 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
     }
 
@@ -422,9 +419,7 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
     }
 
@@ -443,11 +438,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -465,11 +458,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -487,11 +478,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -509,11 +498,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -531,11 +518,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -553,11 +538,9 @@ public class AtpImporterRamAdapterTest {
         LogRecordDto lrDto = atpImporterRamAdapter.createLogRecordDto(logRecord);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))),
+                        argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-        Assert.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
+        Assertions.assertEquals(logRecord.getClass(), lrDto.getLogRecordType());
     }
 
     @Test
@@ -575,9 +558,7 @@ public class AtpImporterRamAdapterTest {
         bulkLogRecordSender.stopBatchSendingTask(erId);
         verify(requestUtils, times(1))
                 .postRequest(eq(urlToSendLr),
-                        argThat(batch -> (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch)
+            argThat(batch -> (batch instanceof List<?> l && l.size() == 1 && l
                                 .stream()
                                 .map(lrDto -> (LogRecordDto) lrDto)
                                 .map(this::extractLrFromDto)
@@ -597,12 +578,11 @@ public class AtpImporterRamAdapterTest {
     }
 
     private boolean isProperDetailsMessage_erIdStatusProjectIdAndMessageAreSet(Object erDetails) {
-        return erDetails instanceof ExecutionRequestDetails
-                && ((ExecutionRequestDetails) erDetails).getExecutionRequestId().equals(erId)
-                && ((ExecutionRequestDetails) erDetails).getStatus().equals(TestingStatuses.FAILED)
-                && ((ExecutionRequestDetails) erDetails).getMessage()
-                .contains(ramInteractionFailureMessage)
-                && ((ExecutionRequestDetails) erDetails).getProjectId().equals(projectId);
+    return erDetails instanceof ExecutionRequestDetails erd
+            && erd.getExecutionRequestId().equals(erId)
+            && erd.getStatus().equals(TestingStatuses.FAILED)
+            && erd.getMessage().contains(ramInteractionFailureMessage)
+            && erd.getProjectId().equals(projectId);
     }
 
     @Test
@@ -622,9 +602,9 @@ public class AtpImporterRamAdapterTest {
         String result = atpImporterRamAdapter.getUploadFileUrl(attribute, message);
 
         // Assert
-        assertFalse("Result String with URL contains space ' ' character but should be encoded.",
-                result.contains(" "));
-        assertTrue("Result String with URL doesnt contain correct fileName param",
-                result.contains("&contentType=screenshotNameKey+withSpaceCharacter&"));
+        assertFalse(result.contains(" "),
+                "Result String with URL contains space ' ' character but should be encoded.");
+        assertTrue(result.contains("&contentType=screenshotNameKey+withSpaceCharacter&"),
+                "Result String with URL doesnt contain correct fileName param");
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpImporterRamAdapterTest.java
@@ -159,7 +159,7 @@ public class AtpImporterRamAdapterTest {
     }
 
     @Test
-    public void finishAllTestRuns_cancelBatchSendingIsInvoked() throws IOException, FailedToCreateRamEntity {
+    public void finishAllTestRuns_cancelBatchSendingIsInvoked() throws FailedToCreateRamEntity {
         List<UUID> uuids = asList(UUID.randomUUID(), UUID.randomUUID());
         atpBulkImporterRamAdapter.finishAllTestRuns(uuids, true);
         verify(mockBulkLogRecordSender, times(1))
@@ -223,8 +223,7 @@ public class AtpImporterRamAdapterTest {
     }
 
     @Test
-    public void testStartAtpRun_RamInvocationFails_FailedToCreateRamEntityIsThrown()
-            throws IOException {
+    public void testStartAtpRun_RamInvocationFails_FailedToCreateRamEntityIsThrown() {
         assertThrows(FailedToCreateRamEntity.class, () -> {
             StartRunRequest startRunRequest = StartRunRequest.getRequestBuilder()
                     .setProjectName("Project")
@@ -292,7 +291,7 @@ public class AtpImporterRamAdapterTest {
                 + RamConstants.ER_PATH
                 + "/" + erId
                 + RamConstants.UPDATE_EXECUTION_STATUS_PATH
-                + "/" + newErStatus.toString()
+                + "/" + newErStatus
                 + "?projectId=" + projectId;
         atpImporterRamAdapter.updateExecutionRequestStatus(newErStatus, erId.toString());
         verify(requestUtils, times(1))
@@ -370,7 +369,7 @@ public class AtpImporterRamAdapterTest {
                 + RamConstants.ER_PATH
                 + "/" + erId
                 + RamConstants.UPDATE_EXECUTION_STATUS_PATH
-                + "/" + newErStatus.toString()
+                + "/" + newErStatus
                 + "?projectId=" + projectId;
         atpImporterRamAdapter.getContext().setExecutionRequestId(erId.toString());
         when(requestUtils.putRequest(eq(urlToUpdateErStatus), eq(null), eq(null)))

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpKafkaRamAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpKafkaRamAdapterTest.java
@@ -17,7 +17,6 @@
 package org.qubership.atp.adapter.common.adapters;
 
 import static java.util.Arrays.asList;
-import static net.sf.ezmorph.test.ArrayAssertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -70,14 +70,14 @@ public class AtpKafkaRamAdapterTest {
         Table.Row row = new Table.Row();
         row.setCells(new LinkedList<>(asList(cell1, cell2)));
         Table table = new Table();
-        table.setRows(new LinkedList<>(asList(row)));
+        table.setRows(new LinkedList<>(List.of(row)));
         logRecord.setTable(table);
         KafkaLogRecord.LogRecord.Builder builder = atpKafkaRamAdapter.createKafkaLogRecord(logRecord);
         assertTrue(builder.hasTable());
-        assertEquals(1, builder.getTable().getRowsCount());
-        assertEquals(2, builder.getTable().getRowsList().get(0).getCellsCount());
-        assertEquals("value1", builder.getTable().getRowsList().get(0).getCellsList().get(0).getValue());
-        assertEquals("value2", builder.getTable().getRowsList().get(0).getCellsList().get(1).getValue());
+        Assertions.assertEquals(1, builder.getTable().getRowsCount());
+        Assertions.assertEquals(2, builder.getTable().getRowsList().getFirst().getCellsCount());
+        Assertions.assertEquals("value1", builder.getTable().getRowsList().getFirst().getCellsList().get(0).getValue());
+        Assertions.assertEquals("value2", builder.getTable().getRowsList().getFirst().getCellsList().get(1).getValue());
     }
 
     @Test
@@ -91,15 +91,15 @@ public class AtpKafkaRamAdapterTest {
         KafkaLogRecord.LogRecord.Builder builder = atpKafkaRamAdapter.createKafkaLogRecord(logRecord);
         List<KafkaLogRecord.CustomLink> resCustomLinks = builder.getCustomLinksList();
         assertNotNull(resCustomLinks);
-        assertEquals(2, resCustomLinks.size());
-        KafkaLogRecord.CustomLink customLink = resCustomLinks.get(0);
-        assertEquals("name1", customLink.getName());
-        assertEquals("http://url1", customLink.getUrl());
-        assertEquals("NEW_TAB", customLink.getOpenMode());
+        Assertions.assertEquals(2, resCustomLinks.size());
+        KafkaLogRecord.CustomLink customLink = resCustomLinks.getFirst();
+        Assertions.assertEquals("name1", customLink.getName());
+        Assertions.assertEquals("http://url1", customLink.getUrl());
+        Assertions.assertEquals("NEW_TAB", customLink.getOpenMode());
         customLink = resCustomLinks.get(1);
-        assertEquals("name2", customLink.getName());
-        assertEquals("http://url2", customLink.getUrl());
-        assertEquals("CURRENT_TAB", customLink.getOpenMode());
+        Assertions.assertEquals("name2", customLink.getName());
+        Assertions.assertEquals("http://url2", customLink.getUrl());
+        Assertions.assertEquals("CURRENT_TAB", customLink.getOpenMode());
     }
 
     public static LogRecord prepareLogRecord() {

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpKafkaRamAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpKafkaRamAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.qubership.atp.adapter.common.adapters;
 
 import static java.util.Arrays.asList;
 import static net.sf.ezmorph.test.ArrayAssertions.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -28,10 +28,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import org.qubership.atp.adapter.common.context.TestRunContext;
 import org.qubership.atp.adapter.common.protos.KafkaLogRecord;
 import org.qubership.atp.adapter.common.utils.ActionParametersTrimmer;
@@ -47,7 +46,7 @@ public class AtpKafkaRamAdapterTest {
 
     private AtpKafkaRamAdapter atpKafkaRamAdapter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         atpKafkaRamAdapter = Mockito.mock(AtpKafkaRamAdapter.class, Mockito.CALLS_REAL_METHODS);
         atpKafkaRamAdapter.actionParametersTrimmer = new ActionParametersTrimmer(256);

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpStandaloneRamAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/AtpStandaloneRamAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -72,8 +72,10 @@ public class AtpStandaloneRamAdapterTest {
         ram2Context.setCompoundAndUpdateCompoundStatuses(compaund);
         ram2Context.setTestScopeId(testScopeId.toString());
         ram2Context.setEnvironmentId(environmentId.toString());
-//        ram2Context.setTestPlanId(testPlanId.toString());
-//        ram2Context.setProjectId(projectId.toString());
+        /*
+        ram2Context.setTestPlanId(testPlanId.toString());
+        ram2Context.setProjectId(projectId.toString());
+         */
 
         return ram2Context;
     }
@@ -119,83 +121,85 @@ public class AtpStandaloneRamAdapterTest {
                 Files.readAllBytes(Paths.get("./src/test/resources", "logRecordsTree.json")));
             due to Stored_Absolute_Path_Traversal and Input_Path_Not_Canonicalized vulnerabilities
          */
-        String jsonRequest = "{ \"testCaseId\": \"257794f0-8c6e-4e01-a95d-bbebf6218a31\",\n"
-                + "  \"metaInfo\": {\n"
-                + "    \"scenarioHashSum\": \"ac458c1b88d799676536b4e673f83360\"\n"
-                + "  },\n"
-                + "  \"trees\": [\n"
-                + "    {\n"
-                + "      \"logRecordId\": null,\n"
-                + "      \"parentRecordId\": null,\n"
-                + "      \"name\": \"section 1\",\n"
-                + "      \"message\": null,\n"
-                + "      \"testingStatus\": \"Unknown\",\n"
-                + "      \"metaInfo\": {\n"
-                + "        \"scenarioId\": \"654de161-3ca5-44c3-bbd7-33263665fe8a\",\n"
-                + "        \"scenarioHashSum\": \"a6d1f65664a59a753c8524f7d8f04d2a\",\n"
-                + "        \"line\": 1\n"
-                + "      },\n"
-                + "      \"configInfo\": null,\n"
-                + "      \"child\": [\n"
-                + "        {\n"
-                + "          \"logRecordId\": null,\n"
-                + "          \"parentRecordId\": null,\n"
-                + "          \"name\": \"message 1\",\n"
-                + "          \"message\": \"there is a body for message 1\",\n"
-                + "          \"testingStatus\": \"Unknown\",\n"
-                + "          \"metaInfo\": null,\n"
-                + "          \"configInfo\": null,\n"
-                + "          \"child\": []\n"
-                + "        },\n"
-                + "        {\n"
-                + "          \"logRecordId\": null,\n"
-                + "          \"parentRecordId\": null,\n"
-                + "          \"name\": \"message 2\",\n"
-                + "          \"message\": \"there is a body for message 2\",\n"
-                + "          \"testingStatus\": \"Unknown\",\n"
-                + "          \"metaInfo\": null,\n"
-                + "          \"configInfo\": null,\n"
-                + "          \"child\": []\n"
-                + "        },\n"
-                + "        {\n"
-                + "          \"logRecordId\": null,\n"
-                + "          \"parentRecordId\": null,\n"
-                + "          \"name\": \"section 2\",\n"
-                + "          \"message\": null,\n"
-                + "          \"testingStatus\": \"Unknown\",\n"
-                + "          \"metaInfo\": {\n"
-                + "            \"scenarioId\": \"b4a9af89-3dc2-4daa-95b5-65e60f079458\",\n"
-                + "            \"scenarioHashSum\": \"scenarioIdHashSum_section2metainfo\",\n"
-                + "            \"line\": 2\n"
-                + "          },\n"
-                + "          \"configInfo\": null,\n"
-                + "          \"child\": [\n"
-                + "            {\n"
-                + "              \"logRecordId\": null,\n"
-                + "              \"parentRecordId\": null,\n"
-                + "              \"name\": \"message 1 from section 2\",\n"
-                + "              \"message\": \"there is a body for message 1 from section 2\",\n"
-                + "              \"testingStatus\": \"Unknown\",\n"
-                + "              \"metaInfo\": null,\n"
-                + "              \"configInfo\": null,\n"
-                + "              \"child\": []\n"
-                + "            },\n"
-                + "            {\n"
-                + "              \"logRecordId\": null,\n"
-                + "              \"parentRecordId\": null,\n"
-                + "              \"name\": \"message 2 from section 2\",\n"
-                + "              \"message\": \"there is a body for message 2 from section 2\",\n"
-                + "              \"testingStatus\": \"Unknown\",\n"
-                + "              \"metaInfo\": null,\n"
-                + "              \"configInfo\": null,\n"
-                + "              \"child\": []\n"
-                + "            }\n"
-                + "          ]\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  ]\n"
-                + "}\n";
+        String jsonRequest = """
+                { "testCaseId": "257794f0-8c6e-4e01-a95d-bbebf6218a31",
+                  "metaInfo": {
+                    "scenarioHashSum": "ac458c1b88d799676536b4e673f83360"
+                  },
+                  "trees": [
+                    {
+                      "logRecordId": null,
+                      "parentRecordId": null,
+                      "name": "section 1",
+                      "message": null,
+                      "testingStatus": "Unknown",
+                      "metaInfo": {
+                        "scenarioId": "654de161-3ca5-44c3-bbd7-33263665fe8a",
+                        "scenarioHashSum": "a6d1f65664a59a753c8524f7d8f04d2a",
+                        "line": 1
+                      },
+                      "configInfo": null,
+                      "child": [
+                        {
+                          "logRecordId": null,
+                          "parentRecordId": null,
+                          "name": "message 1",
+                          "message": "there is a body for message 1",
+                          "testingStatus": "Unknown",
+                          "metaInfo": null,
+                          "configInfo": null,
+                          "child": []
+                        },
+                        {
+                          "logRecordId": null,
+                          "parentRecordId": null,
+                          "name": "message 2",
+                          "message": "there is a body for message 2",
+                          "testingStatus": "Unknown",
+                          "metaInfo": null,
+                          "configInfo": null,
+                          "child": []
+                        },
+                        {
+                          "logRecordId": null,
+                          "parentRecordId": null,
+                          "name": "section 2",
+                          "message": null,
+                          "testingStatus": "Unknown",
+                          "metaInfo": {
+                            "scenarioId": "b4a9af89-3dc2-4daa-95b5-65e60f079458",
+                            "scenarioHashSum": "scenarioIdHashSum_section2metainfo",
+                            "line": 2
+                          },
+                          "configInfo": null,
+                          "child": [
+                            {
+                              "logRecordId": null,
+                              "parentRecordId": null,
+                              "name": "message 1 from section 2",
+                              "message": "there is a body for message 1 from section 2",
+                              "testingStatus": "Unknown",
+                              "metaInfo": null,
+                              "configInfo": null,
+                              "child": []
+                            },
+                            {
+                              "logRecordId": null,
+                              "parentRecordId": null,
+                              "name": "message 2 from section 2",
+                              "message": "there is a body for message 2 from section 2",
+                              "testingStatus": "Unknown",
+                              "metaInfo": null,
+                              "configInfo": null,
+                              "child": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
 
         Scenario scenario = new ObjectMapper().readValue(jsonRequest, Scenario.class);
 

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/BulkLogRecordSenderTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/BulkLogRecordSenderTest.java
@@ -58,7 +58,7 @@ public class BulkLogRecordSenderTest {
     @Mock
     private RequestUtils requestUtils;
 
-  @BeforeEach
+    @BeforeEach
     public void setUp() {
         bulkLogRecordSender = BulkLogRecordSender.getInstance();
         bulkLogRecordSender.requestUtils = requestUtils;
@@ -77,7 +77,7 @@ public class BulkLogRecordSenderTest {
                 .postRequest(any(), argThat(batch ->
                                 (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
                         eq(null));
-  }
+    }
 
     @Test
     public void startBatchSendingTask_scheduledTaskIsStarted_batchIsBoundedByBatchSizeParam() throws IOException,
@@ -151,7 +151,7 @@ public class BulkLogRecordSenderTest {
     }
 
     @Test
-    public void offer_scheduledIsNotStarted_exceptionIsThrown() throws IOException {
+    public void offer_scheduledIsNotStarted_exceptionIsThrown() {
         assertThrows(IllegalStateException.class, () -> {
             LogRecord logRecord = new LogRecord();
             logRecord.setUuid(UUID.randomUUID());
@@ -161,7 +161,7 @@ public class BulkLogRecordSenderTest {
     }
 
     @Test
-    public void offer_scheduledTaskIsStopped_exceptionIsThrown() throws IOException {
+    public void offer_scheduledTaskIsStopped_exceptionIsThrown() {
         assertThrows(IllegalStateException.class, () -> {
             bulkLogRecordSender.startBatchSendingTask(executionRequestId, projectId);
             bulkLogRecordSender.stopBatchSendingTask(executionRequestId);

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/BulkLogRecordSenderTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/BulkLogRecordSenderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package org.qubership.atp.adapter.common.adapters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,19 +31,22 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.utils.RequestUtils;
 import org.qubership.atp.adapter.common.ws.LogRecordDto;
 import org.qubership.atp.ram.models.LogRecord;
 
-@RunWith(MockitoJUnitRunner.class)
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class BulkLogRecordSenderTest {
 
     private BulkLogRecordSender bulkLogRecordSender;
@@ -54,7 +58,7 @@ public class BulkLogRecordSenderTest {
     @Mock
     private RequestUtils requestUtils;
 
-    @Before
+  @BeforeEach
     public void setUp() {
         bulkLogRecordSender = BulkLogRecordSender.getInstance();
         bulkLogRecordSender.requestUtils = requestUtils;
@@ -71,10 +75,9 @@ public class BulkLogRecordSenderTest {
         Thread.sleep(RamConstants.DEFAULT_LOGRECORD_BATCHING_TIMEOUT * 2);
         verify(requestUtils, atLeast(1))
                 .postRequest(any(), argThat(batch ->
-                        (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))), eq(null));
-    }
+                                (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))),
+                        eq(null));
+  }
 
     @Test
     public void startBatchSendingTask_scheduledTaskIsStarted_batchIsBoundedByBatchSizeParam() throws IOException,
@@ -89,9 +92,9 @@ public class BulkLogRecordSenderTest {
         Thread.sleep(RamConstants.DEFAULT_LOGRECORD_BATCHING_TIMEOUT * 2);
         verify(requestUtils, never())
                 .postRequest(any(), argThat(batch ->
-                        (batch instanceof List
-                                && ((List<?>) batch).size() > RamConstants.DEFAULT_LOGRECORD_BATCH_SIZE
-                                && ((List<?>) batch).contains(lrDto))), eq(null));
+            (batch instanceof List<?> l
+                && l.size() > RamConstants.DEFAULT_LOGRECORD_BATCH_SIZE
+                && l.contains(lrDto))), eq(null));
     }
 
     @Test
@@ -121,11 +124,12 @@ public class BulkLogRecordSenderTest {
         verify(requestUtils, atLeast(5))
                 .postRequest(any(),
                         argThat(batch -> {
-                            if (batch instanceof List) {
-                                lrCounter.getAndAdd(((List<?>) batch).size());
+                            if (batch instanceof List<?> list) {
+                                lrCounter.getAndAdd(list.size());
                                 return true;
-                            } else
+                            } else {
                                 return false;
+                            }
                         }),
                         eq(null));
         assertEquals(threadCount * RamConstants.DEFAULT_LOGRECORD_BATCH_SIZE, lrCounter.get());
@@ -143,27 +147,29 @@ public class BulkLogRecordSenderTest {
         Thread.sleep(RamConstants.DEFAULT_LOGRECORD_BATCHING_TIMEOUT * 2);
         verify(requestUtils, atLeast(1))
                 .postRequest(any(), argThat(batch ->
-                        (batch instanceof List
-                                && ((List<?>) batch).size() == 1
-                                && ((List<?>) batch).contains(lrDto))), eq(null));
+                        (batch instanceof List<?> l && l.size() == 1 && l.contains(lrDto))), eq(null));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void offer_scheduledIsNotStarted_exceptionIsThrown() throws IOException{
-        LogRecord logRecord = new LogRecord();
-        logRecord.setUuid(UUID.randomUUID());
-        LogRecordDto lrDto = createLogRecordDto(logRecord);
-        bulkLogRecordSender.offer(lrDto, executionRequestId);
+    @Test
+    public void offer_scheduledIsNotStarted_exceptionIsThrown() throws IOException {
+        assertThrows(IllegalStateException.class, () -> {
+            LogRecord logRecord = new LogRecord();
+            logRecord.setUuid(UUID.randomUUID());
+            LogRecordDto lrDto = createLogRecordDto(logRecord);
+            bulkLogRecordSender.offer(lrDto, executionRequestId);
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void offer_scheduledTaskIsStopped_exceptionIsThrown() throws IOException{
-        bulkLogRecordSender.startBatchSendingTask(executionRequestId, projectId);
-        bulkLogRecordSender.stopBatchSendingTask(executionRequestId);
-        LogRecord logRecord = new LogRecord();
-        logRecord.setUuid(UUID.randomUUID());
-        LogRecordDto lrDto = createLogRecordDto(logRecord);
-        bulkLogRecordSender.offer(lrDto, executionRequestId);
+    @Test
+    public void offer_scheduledTaskIsStopped_exceptionIsThrown() throws IOException {
+        assertThrows(IllegalStateException.class, () -> {
+            bulkLogRecordSender.startBatchSendingTask(executionRequestId, projectId);
+            bulkLogRecordSender.stopBatchSendingTask(executionRequestId);
+            LogRecord logRecord = new LogRecord();
+            logRecord.setUuid(UUID.randomUUID());
+            LogRecordDto lrDto = createLogRecordDto(logRecord);
+            bulkLogRecordSender.offer(lrDto, executionRequestId);
+        });
     }
 
     private LogRecordDto createLogRecordDto(LogRecord logRecordRequest) throws JsonProcessingException {

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/KafkaAdapterTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/adapters/KafkaAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,11 +23,10 @@ import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.kafka.pool.KafkaPoolManagementService;
 import org.qubership.atp.adapter.common.kafka.pool.KafkaProducersPooledObjectFactory;
@@ -42,7 +41,7 @@ public class KafkaAdapterTest {
 
     KafkaProducersPooledObjectFactory kafkaProducersPooledObjectFactory = new KafkaProducersPooledObjectFactory();
 
-    @Before
+    @BeforeEach
     public void init() {
         Config cfg = Config.getConfig();
         cfg.setProperty(RamConstants.KAFKA_PRODUCERS_POOL_MAX_TOTAL_PER_KEY, String.valueOf(poolSize));
@@ -61,7 +60,7 @@ public class KafkaAdapterTest {
         Mockito.doNothing().when(kafkaPoolManagementService).sendRecord(Mockito.any(), Mockito.any());
         kafkaPoolManagementService.sendProducerRecord(new ProducerRecord("", ""), ProducerType.PROTOBUF);
         Mockito.verify(kafkaPoolManagementService, Mockito.times(1)).sendRecord(Mockito.any(), Mockito.any());
-        Assert.assertEquals(1, kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
+        Assertions.assertEquals(1, kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
     }
 
     @Test
@@ -74,7 +73,7 @@ public class KafkaAdapterTest {
         kafkaPoolManagementService.sendProducerRecord(new ProducerRecord("", ""), ProducerType.PROTOBUF);
         kafkaPoolManagementService.sendProducerRecord(new ProducerRecord("", ""), ProducerType.PROTOBUF);
         Mockito.verify(kafkaPoolManagementService, Mockito.times(6)).sendRecord(Mockito.any(), Mockito.any());
-        Assert.assertEquals(1, kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
+        Assertions.assertEquals(1, kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
     }
 
     @Test
@@ -102,7 +101,7 @@ public class KafkaAdapterTest {
         latch6.await();
 
         Mockito.verify(kafkaPoolManagementService, Mockito.times(6)).sendRecord(Mockito.any(), Mockito.any());
-        Assert.assertTrue(poolSize >= kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
+        Assertions.assertTrue(poolSize >= kafkaPoolManagementService.getKafkaProducersKeyedPool().getCreatedCount());
     }
 
     class SendThread implements Runnable {

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/context/LogRecordsStackTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/context/LogRecordsStackTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.qubership.atp.adapter.common.context;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.ram.enums.ExecutionStatuses;
 import org.qubership.atp.ram.enums.TestingStatuses;
 import org.qubership.atp.ram.models.LogRecord;
@@ -33,7 +32,7 @@ public class LogRecordsStackTest {
 
         LogRecordsStack stack = new LogRecordsStack();
         stack.push(logRecord);
-        Assert.assertFalse("Current log record should not be changed", stack.isCurrentLogRecordChanged());
+        Assertions.assertFalse(stack.isCurrentLogRecordChanged(), "Current log record should not be changed");
     }
 
     @Test
@@ -45,7 +44,7 @@ public class LogRecordsStackTest {
         LogRecordsStack stack = new LogRecordsStack();
         stack.push(logRecord);
         logRecord.setTestingStatus(TestingStatuses.PASSED);
-        Assert.assertTrue("Current log record should be changed", stack.isCurrentLogRecordChanged());
+        Assertions.assertTrue(stack.isCurrentLogRecordChanged(), "Current log record should be changed");
     }
 
     @Test
@@ -70,12 +69,12 @@ public class LogRecordsStackTest {
         logRecord.setTestingStatus(TestingStatuses.PASSED);
         logRecord3.setDuration(10);
 
-        Assert.assertTrue("Current log record should be changed", stack.isCurrentLogRecordChanged());
+        Assertions.assertTrue(stack.isCurrentLogRecordChanged(), "Current log record should be changed");
         stack.pop();
-        Assert.assertFalse("Current log record should not be changed", stack.isCurrentLogRecordChanged());
+        Assertions.assertFalse(stack.isCurrentLogRecordChanged(), "Current log record should not be changed");
         stack.pop();
-        Assert.assertTrue("Current log record should be changed", stack.isCurrentLogRecordChanged());
+        Assertions.assertTrue(stack.isCurrentLogRecordChanged(), "Current log record should be changed");
         stack.pop();
-        Assert.assertTrue("Stack should be empty", stack.isEmpty());
+        Assertions.assertTrue(stack.isEmpty(), "Stack should be empty");
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ActionParametersTrimmerTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ActionParametersTrimmerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.qubership.atp.adapter.common.utils;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ActionParametersTrimmerTest {
 
     private ActionParametersTrimmer actionParametersTrimmer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         actionParametersTrimmer = new ActionParametersTrimmer(12);
     }
@@ -43,7 +43,7 @@ public class ActionParametersTrimmerTest {
         String expected =
                 "Store value \"big value...\" and \"big value...\" and \"big value...\"and (\"small value\", \"big value...\")";
         String result = actionParametersTrimmer.trimActionParametersByLimit(step);
-        Assert.assertEquals(expected, result);
+        Assertions.assertEquals(expected, result);
     }
 
     @Test
@@ -51,6 +51,6 @@ public class ActionParametersTrimmerTest {
         String step = "Store value \"MRC with \\\\\\\"Installation\\\\\\\"\"";
         String result = actionParametersTrimmer.trimActionParametersByLimit(step);
         String expected = "Store value \"MRC with ...\"";
-        Assert.assertEquals(expected, result);
+        Assertions.assertEquals(expected, result);
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ConfigTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,39 +16,39 @@
 
 package org.qubership.atp.adapter.common.utils;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         System.clearProperty("atp.url");
     }
 
     @Test
     public void getConfig() {
-        Assert.assertNotNull(Config.getConfig());
+        Assertions.assertNotNull(Config.getConfig());
     }
 
     @Test
     public void getPropertyWithoutDefaultValue() {
         String value = "http://localhost:8081";
-        Assert.assertEquals(value, Config.getConfig().getProperty("atp.url"));
-        Assert.assertNull(Config.getConfig().getProperty("atp2.url"));
+        Assertions.assertEquals(value, Config.getConfig().getProperty("atp.url"));
+        Assertions.assertNull(Config.getConfig().getProperty("atp2.url"));
     }
 
     @Test
     public void getPropertyWithDefaultValue() {
         String defValue = "http://localhost:8888";
-        Assert.assertNotEquals(defValue, Config.getConfig().getProperty("atp.url", defValue));
-        Assert.assertEquals(defValue, Config.getConfig().getProperty("atp2.url", defValue));
+        Assertions.assertNotEquals(defValue, Config.getConfig().getProperty("atp.url", defValue));
+        Assertions.assertEquals(defValue, Config.getConfig().getProperty("atp2.url", defValue));
     }
 
     @Test
     public void allPropertiesFilesShouldBeLoaded() {
-        Assert.assertNotNull(Config.getConfig().getProperty("atp3.url"));
+        Assertions.assertNotNull(Config.getConfig().getProperty("atp3.url"));
     }
 
     @Test
@@ -60,18 +60,18 @@ public class ConfigTest {
     public void setProperty() {
         String key = "prop.should.be.empty";
         String value = "newValue";
-        Assert.assertNull(Config.getConfig().getProperty(key));
+        Assertions.assertNull(Config.getConfig().getProperty(key));
         Config.getConfig().setProperty(key, value);
-        Assert.assertEquals(value, Config.getConfig().getProperty(key));
+        Assertions.assertEquals(value, Config.getConfig().getProperty(key));
     }
 
     @Test
     public void systemPropertyShouldBePriority() {
         String value = "http://localhost:8081";
         String newValue = "http://localhost:8181";
-        Assert.assertEquals(Config.getConfig().getProperty("atp.url"), value);
+        Assertions.assertEquals(Config.getConfig().getProperty("atp.url"), value);
         System.setProperty("atp.url", newValue);
         System.out.println(Config.getConfig().getProperty("atp.url"));
-        Assert.assertEquals(newValue, Config.getConfig().getProperty("atp.url"));
+        Assertions.assertEquals(newValue, Config.getConfig().getProperty("atp.url"));
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ConfigTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ConfigTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 public class ConfigTest {
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         System.clearProperty("atp.url");
     }
 
@@ -69,9 +69,9 @@ public class ConfigTest {
     public void systemPropertyShouldBePriority() {
         String value = "http://localhost:8081";
         String newValue = "http://localhost:8181";
-        Assertions.assertEquals(Config.getConfig().getProperty("atp.url"), value);
+        Assertions.assertEquals(value, Config.getConfig().getProperty("atp.url"));
         System.setProperty("atp.url", newValue);
-        System.out.println(Config.getConfig().getProperty("atp.url"));
+        //System.out.println(Config.getConfig().getProperty("atp.url"));
         Assertions.assertEquals(newValue, Config.getConfig().getProperty("atp.url"));
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ExecutionRequestHelperTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ExecutionRequestHelperTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package org.qubership.atp.adapter.common.utils;
 
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,9 +34,8 @@ import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.adapter.common.RamConstants;
 
 public class ExecutionRequestHelperTest {
@@ -46,7 +45,7 @@ public class ExecutionRequestHelperTest {
         String requestName = ExecutionRequestHelper.generateRequestName();
         Pattern p = Pattern.compile("(Default)\\s(ER)\\s(\\d{1,2})\\.(\\d{1,2})\\.(\\d{4}) (\\d{1,2}):(\\d{2})");
         Matcher m = p.matcher(requestName);
-        Assert.assertTrue(m.matches());
+        Assertions.assertTrue(m.matches());
     }
 
 
@@ -74,8 +73,8 @@ public class ExecutionRequestHelperTest {
         Future<String> futureResult2 = executors.submit(callable2);
         String result2 = futureResult2.get();
 
-        Assert.assertEquals(result1, result2);
-        Assert.assertEquals("32_9.3.NC.ATP.CD91_rev13108", result1);
+        Assertions.assertEquals(result1, result2);
+        Assertions.assertEquals("32_9.3.NC.ATP.CD91_rev13108", result1);
         verify(getter2, times(0)).connectAndFetchPage(anyString());
     }
 
@@ -89,30 +88,29 @@ public class ExecutionRequestHelperTest {
 
         String result1 = getter1.getSolutionBuild("url");
 
-        Assert.assertEquals("Unknown solution build", result1);
+        Assertions.assertEquals("Unknown solution build", result1);
     }
 
     @Test
     public void parseResponse() {
-        String response = "<S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
-                "   <S:Body>\n" +
-                "      <ns2:startRunResponse xmlns:ns2=\"http://server.ws.integration.atp.solutions.somedomain.com/\">\n"
-                +
-                "         <RunResponse>\n" +
-                "            <executionRequestInfo>\n" +
-                "               <reportLink>http://qaapp125.somedomain.com:6820/common/uobject.jsp?tab=_Test+Run+Tree+View&amp;object=9151562714613898495</reportLink>\n"
-                +
-                "            </executionRequestInfo>\n" +
-                "            <testRunId>9151562714613898494</testRunId>\n" +
-                "            <recordId>9151562714613898494</recordId>\n" +
-                "         </RunResponse>\n" +
-                "      </ns2:startRunResponse>\n" +
-                "   </S:Body>\n" +
-                "</S:Envelope>";
+        String response = """
+                <S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+                   <S:Body>
+                      <ns2:startRunResponse xmlns:ns2="http://server.ws.integration.atp.solutions.somedomain.com/">
+                         <RunResponse>
+                            <executionRequestInfo>
+                               <reportLink>http://qaapp125.somedomain.com:6820/common/uobject.jsp?tab=_Test+Run+Tree+View&amp;object=9151562714613898495</reportLink>
+                            </executionRequestInfo>
+                            <testRunId>9151562714613898494</testRunId>
+                            <recordId>9151562714613898494</recordId>
+                         </RunResponse>
+                      </ns2:startRunResponse>
+                   </S:Body>
+                </S:Envelope>""";
         Map<String, String> result = ExecutionRequestHelper.parseResponse(response);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.containsKey(RamConstants.TEST_RUN_ID_KEY));
-        Assert.assertTrue(result.containsKey(RamConstants.RECORD_ID_KEY));
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.containsKey(RamConstants.TEST_RUN_ID_KEY));
+        Assertions.assertTrue(result.containsKey(RamConstants.RECORD_ID_KEY));
     }
 
     @Test

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ExecutionRequestHelperTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/ExecutionRequestHelperTest.java
@@ -79,8 +79,7 @@ public class ExecutionRequestHelperTest {
     }
 
     @Test
-    public void getSolutionBuild_whenGetSolutionBuildNotEnabled_resultIsDefault()
-            throws IOException, ExecutionException, InterruptedException {
+    public void getSolutionBuild_whenGetSolutionBuildNotEnabled_resultIsDefault() throws IOException {
         SolutionBuildGetter getter1 = mock(SolutionBuildGetter.class);
         when(getter1.connectAndFetchPage(anyString()))
                 .thenReturn("9.3.NC.ATP.CD91\nbuild_number:32_9.3.NC.ATP.CD91_rev13108");
@@ -115,10 +114,9 @@ public class ExecutionRequestHelperTest {
 
     @Test
     public void testEqualsString() {
-        String a1 = new String("TEST");
-        String a2 = new String("TEST");
+        String a1 = "TEST";
+        String a2 = "TEST";
         System.out.println(a1 == a2);
         System.out.println(a1.equals(a2));
-
     }
 }

--- a/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/UtilsTest.java
+++ b/qubership-atp-adapter-common/src/test/java/org/qubership/atp/adapter/common/utils/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,55 +20,57 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.ram.enums.BvStatus;
 import org.qubership.atp.ram.enums.TestingStatuses;
 import org.qubership.atp.ram.models.logrecords.parts.ValidationTable;
 import org.qubership.atp.ram.models.logrecords.parts.ValidationTableLine;
+
 import net.sf.json.JSONObject;
 
 public class UtilsTest {
-    private static final String compareResult = "{\n"
-            + "    \"tcId\": \"5a117edc-fad7-423a-abe9-51d7084a396b\",\n"
-            + "    \"tcName\": \"OCS.Product.Smoke. Successful Data Customer creation for sanity\",\n"
-            + "    \"compareResult\": \"MODIFIED\",\n"
-            + "    \"trDate\": null,\n"
-            + "    \"trId\": \"1\",\n"
-            + "    \"resultLink\": \"http://localhost:8080/bvtool/#/validation?trid=1\",\n"
-            + "    \"steps\": [\n"
-            + "        {\n"
-            + "            \"objectId\": \"d971d7f9-e162-4b95-b72d-a8302651d529\",\n"
-            + "            \"stepName\": \"123\",\n"
-            + "            \"compareResult\": \"IDENTICAL\",\n"
-            + "            \"diffs\": [],\n"
-            + "            \"highlightedEr\": \"123\\n\",\n"
-            + "            \"highlightedAr\": \"123\\n\"\n"
-            + "        },\n"
-            + "        {\n"
-            + "            \"objectId\": \"33e92903-d400-45ee-be4a-e2b0bbc9f7c3\",\n"
-            + "            \"stepName\": \"CCA-T\",\n"
-            + "            \"compareResult\": \"MODIFIED\",\n"
-            + "            \"diffs\": [\n"
-            + "                {\n"
-            + "                    \"orderId\": 1,\n"
-            + "                    \"expected\": \"0-0\",\n"
-            + "                    \"actual\": \"0-0\",\n"
-            + "                    \"description\": \"ER row(s)## 0-0 are replaced with AR row(s)## 0-0\",\n"
-            + "                    \"result\": \"MODIFIED\"\n"
-            + "                }\n"
-            + "            ],\n"
-            + "            \"highlightedEr\": \"<span data-block-id=\\\"pc-highlight-block\\\" class=\\\"MODIFIED\\\">234\\n</span>\",\n"
-            + "            \"highlightedAr\": \"<span data-block-id=\\\"pc-highlight-block\\\" class=\\\"MODIFIED\\\">123\\n</span>\"\n"
-            + "        }]\n"
-            + "}";
+    private static final String compareResult = """
+            {
+                "tcId": "5a117edc-fad7-423a-abe9-51d7084a396b",
+                "tcName": "OCS.Product.Smoke. Successful Data Customer creation for sanity",
+                "compareResult": "MODIFIED",
+                "trDate": null,
+                "trId": "1",
+                "resultLink": "http://localhost:8080/bvtool/#/validation?trid=1",
+                "steps": [
+                    {
+                        "objectId": "d971d7f9-e162-4b95-b72d-a8302651d529",
+                        "stepName": "123",
+                        "compareResult": "IDENTICAL",
+                        "diffs": [],
+                        "highlightedEr": "123\\n",
+                        "highlightedAr": "123\\n"
+                    },
+                    {
+                        "objectId": "33e92903-d400-45ee-be4a-e2b0bbc9f7c3",
+                        "stepName": "CCA-T",
+                        "compareResult": "MODIFIED",
+                        "diffs": [
+                            {
+                                "orderId": 1,
+                                "expected": "0-0",
+                                "actual": "0-0",
+                                "description": "ER row(s)## 0-0 are replaced with AR row(s)## 0-0",
+                                "result": "MODIFIED"
+                            }
+                        ],
+                        "highlightedEr": "<span data-block-id=\\"pc-highlight-block\\" class=\\"MODIFIED\\">234\\n</span>",
+                        "highlightedAr": "<span data-block-id=\\"pc-highlight-block\\" class=\\"MODIFIED\\">123\\n</span>"
+                    }]
+            }\
+            """;
 
     @Test
     public void parseValidationTableFromJson_CompareTwoObject_ReturnValidValidationTable() throws IOException {
         ValidationTable expectedResult = createValidationTable();
         ValidationTable result = Utils.parseValidationTableFromJson(JSONObject.fromObject(compareResult));
-        Assert.assertEquals(expectedResult, result);
+        Assertions.assertEquals(expectedResult, result);
     }
 
     private ValidationTable createValidationTable() {

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -142,6 +142,12 @@
             <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.23.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>4.5.73-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 
@@ -79,9 +79,15 @@
             <version>1.5.2</version>
         </dependency>
         <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
-            <version>1.3</version>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-legacy</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.14.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tony19</groupId>
@@ -98,6 +104,12 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
             <version>2.27</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -120,28 +132,10 @@
             <artifactId>oval</artifactId>
             <version>1.84</version>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -320,7 +314,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.20.1</version>
+                        <version>3.1.2</version>
                         <executions>
                             <!-- execute all integration (mostly UI tests) -->
                             <execution>

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -87,12 +87,12 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-legacy</artifactId>
             <version>2.11.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -32,6 +32,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.qubership.atp.adapter.robot</groupId>
@@ -86,6 +87,12 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-legacy</artifactId>
             <version>2.11.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/qubership-atp-adapter-executor/pom.xml
+++ b/qubership-atp-adapter-executor/pom.xml
@@ -30,6 +30,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.qubership.atp.adapter.robot</groupId>
             <artifactId>qubership-atp-adapter-common</artifactId>
             <version>${project.version}</version>

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/CellPosition.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/CellPosition.java
@@ -17,8 +17,8 @@
 package org.qubership.atp.adapter.excel;
 
 public class CellPosition implements Comparable {
-    private int rowNum;
-    private int colNum;
+    private final int rowNum;
+    private final int colNum;
 
     public CellPosition(int rowNum, int colNum) {
         this.rowNum = rowNum;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/CellPosition.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/CellPosition.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ public class CellPosition implements Comparable {
     }
 
     public int compareTo(Object o) {
-        if (o != null && o instanceof CellPosition) {
-            CellPosition position = (CellPosition)o;
+        if (o != null && o instanceof CellPosition position) {
             int colDiff = position.getColNum() - this.getColNum();
             int rowDiff = position.getRowNum() - this.getRowNum();
             if (colDiff == 0 && rowDiff == 0) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelBook.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelBook.java
@@ -38,7 +38,7 @@ import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException
 import org.qubership.atp.adapter.excel.exceptions.RecordingInFileException;
 
 public class ExcelBook {
-    private static Log log = LogFactory.getLog(ExcelBook.class);
+    private static final Log log = LogFactory.getLog(ExcelBook.class);
     private Workbook workbook;
     private File currentFile;
     private ExcelSheet sheet;
@@ -76,18 +76,15 @@ public class ExcelBook {
                 }
 
                 this.currentFile = file;
-            } catch (IOException var13) {
-                IOException ex = var13;
+            } catch (IOException ex) {
                 throw new InvalidFormatOfSourceException("Could not read '%s' file".formatted(file.getAbsolutePath()), ex);
-            } catch (InvalidFormatException var14) {
-                InvalidFormatException ex = var14;
+            } catch (InvalidFormatException ex) {
                 throw new InvalidFormatOfSourceException("Invalid format of '%s' file : ".formatted(this.currentFile.getName()), ex);
             } finally {
                 if (fis != null) {
                     try {
                         fis.close();
-                    } catch (IOException var12) {
-                        IOException e = var12;
+                    } catch (IOException e) {
                         log.error(e.getMessage());
                     }
                 }
@@ -145,21 +142,17 @@ public class ExcelBook {
         try {
             fileOut = new FileOutputStream(this.getCurrentFile());
             this.workbook.write(fileOut);
-        } catch (IOException var6) {
-            IOException ex = var6;
+        } catch (IOException ex) {
             if (this.workbook instanceof SXSSFWorkbook) {
                 log.error("XSSFWorkbook saving exception. You can use it only once. Otherwise - you should open file again", ex);
             }
-
             throw new RecordingInFileException("Recording has been attempted in open file. File: " + this.getCurrentFile().getName() + " being used by another process.", ex);
         } finally {
             if (fileOut != null) {
                 fileOut.flush();
                 fileOut.close();
             }
-
         }
-
     }
 
     public Workbook getWorkbook() {
@@ -223,7 +216,7 @@ public class ExcelBook {
 
     public ExcelSheet cloneSheet(int sheetIndex) throws InvalidFormatOfSourceException {
         this.validateSheetIndex(sheetIndex);
-        return this.cloneSheet(sheetIndex, (String)null);
+        return this.cloneSheet(sheetIndex, null);
     }
 
     public ExcelSheet cloneSheet(int sheetIndex, String newSheetName) throws InvalidFormatOfSourceException {
@@ -242,9 +235,9 @@ public class ExcelBook {
     }
 
     public Iterator<ExcelSheet> iterator() {
-        return new Iterator<ExcelSheet>() {
+        return new Iterator<>() {
             int index = 1;
-            int endIndex = ExcelBook.this.getMaxSheetNum();
+            final int endIndex = ExcelBook.this.getMaxSheetNum();
 
             public boolean hasNext() {
                 return this.index <= this.endIndex;
@@ -290,23 +283,18 @@ public class ExcelBook {
 
             out = new FileOutputStream(file);
             ((Workbook)wb).write(out);
-        } catch (IOException var14) {
-            IOException ex = var14;
-            ex.printStackTrace();
+        } catch (IOException ex) {
+            log.error(ex);
         } finally {
             if (out != null) {
                 try {
                     out.flush();
                     out.close();
-                } catch (IOException var13) {
-                    IOException e = var13;
-                    e.printStackTrace();
+                } catch (IOException e) {
                     log.fatal("Error during reading ExcelBook: " + e.getMessage());
                 }
             }
-
         }
-
     }
 
     private void validateSheetIndex(int sheetIndex) {
@@ -316,7 +304,7 @@ public class ExcelBook {
     }
 
     public boolean equals(Object object) {
-        return !(object instanceof ExcelBook) ? false : this.toString().equals(((ExcelBook)object).toString());
+        return !(object instanceof ExcelBook) ? false : this.toString().equals(object.toString());
     }
 
     public void close() throws IOException {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelBook.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelBook.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.qubership.atp.adapter.excel;
 
-import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException;
-import org.qubership.atp.adapter.excel.exceptions.RecordingInFileException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -25,6 +23,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
@@ -35,6 +34,8 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException;
+import org.qubership.atp.adapter.excel.exceptions.RecordingInFileException;
 
 public class ExcelBook {
     private static Log log = LogFactory.getLog(ExcelBook.class);
@@ -68,8 +69,8 @@ public class ExcelBook {
 
             try {
                 Workbook wb = WorkbookFactory.create(fis = new FileInputStream(file));
-                if (wb instanceof XSSFWorkbook && isSXSSFWorkbook) {
-                    this.workbook = new SXSSFWorkbook((XSSFWorkbook)wb, 999999);
+                if (wb instanceof XSSFWorkbook fWorkbook && isSXSSFWorkbook) {
+                    this.workbook = new SXSSFWorkbook(fWorkbook, 999999);
                 } else {
                     this.workbook = wb;
                 }
@@ -77,10 +78,10 @@ public class ExcelBook {
                 this.currentFile = file;
             } catch (IOException var13) {
                 IOException ex = var13;
-                throw new InvalidFormatOfSourceException(String.format("Could not read '%s' file", file.getAbsolutePath()), ex);
+                throw new InvalidFormatOfSourceException("Could not read '%s' file".formatted(file.getAbsolutePath()), ex);
             } catch (InvalidFormatException var14) {
                 InvalidFormatException ex = var14;
-                throw new InvalidFormatOfSourceException(String.format("Invalid format of '%s' file : ", this.currentFile.getName()), ex);
+                throw new InvalidFormatOfSourceException("Invalid format of '%s' file : ".formatted(this.currentFile.getName()), ex);
             } finally {
                 if (fis != null) {
                     try {
@@ -122,7 +123,7 @@ public class ExcelBook {
 
     public ExcelSheet openSheet(String newSheetName, int headerRowIndex, String[] headerRowIdentifiers) throws InvalidFormatOfSourceException {
         if (!this.hasSheet(newSheetName)) {
-            throw new InvalidFormatOfSourceException(String.format("Sheet '%s' hasn't been found in the '%s' WB", newSheetName, this.currentFile.getName()));
+            throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB".formatted(newSheetName, this.currentFile.getName()));
         } else {
             if (this.sheet == null || !this.sheet.getSheetName().equalsIgnoreCase(newSheetName)) {
                 this.sheet = null;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelCell.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelCell.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 package org.qubership.atp.adapter.excel;
 
-import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException;
-import org.qubership.atp.adapter.excel.style.ExcelCellStyle;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.poi.ss.format.CellFormat;
@@ -32,6 +31,8 @@ import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException;
+import org.qubership.atp.adapter.excel.style.ExcelCellStyle;
 
 public class ExcelCell {
     private static Log log = LogFactory.getLog(ExcelCell.class);
@@ -84,8 +85,8 @@ public class ExcelCell {
                 } catch (Exception var6) {
                     Exception e = var6;
                     if (this.cell.getCellType() == 5) {
-                        if (this.cell instanceof XSSFCell) {
-                            result = ((XSSFCell)this.cell).getErrorCellString();
+                        if (this.cell instanceof XSSFCell fCell) {
+                            result = fCell.getErrorCellString();
                         } else {
                             result = "####";
                         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelCell.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelCell.java
@@ -35,11 +35,11 @@ import org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException
 import org.qubership.atp.adapter.excel.style.ExcelCellStyle;
 
 public class ExcelCell {
-    private static Log log = LogFactory.getLog(ExcelCell.class);
+    private static final Log log = LogFactory.getLog(ExcelCell.class);
     private Cell cell;
     private String value;
     private boolean isChanged = false;
-    private CellPosition position;
+    private final CellPosition position;
 
     public ExcelCell(Cell cell) {
         this.cell = cell;
@@ -82,8 +82,7 @@ public class ExcelCell {
                     } else {
                         result = form.formatCellValue(this.cell, evaluator);
                     }
-                } catch (Exception var6) {
-                    Exception e = var6;
+                } catch (Exception e) {
                     if (this.cell.getCellType() == 5) {
                         if (this.cell instanceof XSSFCell fCell) {
                             result = fCell.getErrorCellString();
@@ -91,11 +90,11 @@ public class ExcelCell {
                             result = "####";
                         }
                     }
-
-                    throw new InvalidFormatOfSourceException("Cell parsing error\tSheet: " + this.cell.getSheet().getSheetName() + ", " + "\tRow: " + (this.cell.getRowIndex() + 1) + ", " + "\tCell: " + (this.cell.getColumnIndex() + 1) + ", " + "\tValue: " + result, e);
+                    throw new InvalidFormatOfSourceException("Cell parsing error\tSheet: "
+                            + this.cell.getSheet().getSheetName() + ", " + "\tRow: " + (this.cell.getRowIndex() + 1)
+                            + ", " + "\tCell: " + (this.cell.getColumnIndex() + 1) + ", " + "\tValue: " + result, e);
                 }
             }
-
             return result;
         }
     }
@@ -134,17 +133,9 @@ public class ExcelCell {
             Method getCellFormatType = CellFormatPart.class.getDeclaredMethod("getCellFormatType", (Class[])null);
             getCellFormatType.setAccessible(true);
             return (CellFormatType)getCellFormatType.invoke(new CellFormatPart(dataFormatString.replaceAll(";", "")));
-        } catch (InvocationTargetException var3) {
-            InvocationTargetException e = var3;
-            e.printStackTrace();
-        } catch (IllegalAccessException var4) {
-            IllegalAccessException e = var4;
-            e.printStackTrace();
-        } catch (NoSuchMethodException var5) {
-            NoSuchMethodException e = var5;
-            e.printStackTrace();
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            log.error(e);
         }
-
         log.error("CellFormatType can't be taken. General value will be returned.");
         return CellFormatType.GENERAL;
     }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelSheet.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelSheet.java
@@ -53,7 +53,7 @@ public class ExcelSheet {
         this.excelBook = excelBook;
         this.currentSheetName = sheetName;
         if (!excelBook.hasSheet(sheetName)) {
-            throw new InvalidFormatOfSourceException(String.format("Sheet '%s' hasn't been found in the '%s' WB", sheetName, this.getExcelBookName()));
+            throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB".formatted(sheetName, this.getExcelBookName()));
         } else {
             this.setCurrentSheet(excelBook.getWorkbook().getSheet(sheetName));
             this.calculateHeaders(currentRowIndex, headerRowIdentifiers);
@@ -95,8 +95,8 @@ public class ExcelSheet {
                 }
             } else {
                 throw new InvalidFormatOfSourceException(
-                        String.format("Header row on '%s' sheet hasn't been defined. File name is '%s'.",
-                                this.getSheetName(), this.getExcelBookName()));
+                    "Header row on '%s' sheet hasn't been defined. File name is '%s'.".formatted(
+                        this.getSheetName(), this.getExcelBookName()));
             }
         }
     }
@@ -166,11 +166,11 @@ public class ExcelSheet {
         if (!indexes.isEmpty() && indexes.get(0) != -1) {
             return this.getRow(rowNumber).getCell(indexes.get(0));
         } else {
-            String basicMessage = String.format("Error during operation with headers. Excel file name is '%s', excel sheet name is '%s'. Header row index = %s", this.getExcelBookName(), this.getSheetName(), this.headerRowIndex);
+            String basicMessage = "Error during operation with headers. Excel file name is '%s', excel sheet name is '%s'. Header row index = %s".formatted(this.getExcelBookName(), this.getSheetName(), this.headerRowIndex);
             if (this.getHeaderRowIndex() <= -1) {
-                throw new DataNotSetException(String.format("%s. Header row is not defined!", basicMessage));
+                throw new DataNotSetException("%s. Header row is not defined!".formatted(basicMessage));
             } else {
-                throw new DataNotSetException(String.format("%s. Header name '%s' doesn't exist in header row: '%s'", basicMessage, headerName, this.headers.values()));
+                throw new DataNotSetException("%s. Header name '%s' doesn't exist in header row: '%s'".formatted(basicMessage, headerName, this.headers.values()));
             }
         }
     }
@@ -354,7 +354,7 @@ public class ExcelSheet {
     }
 
     public boolean equals(Object object) {
-        return object instanceof ExcelSheet && this.toString().equals(((ExcelSheet) object).toString());
+        return object instanceof ExcelSheet es && this.toString().equals(es.toString());
     }
 
     public ExcelBook getExcelBook() {
@@ -391,24 +391,24 @@ public class ExcelSheet {
     }
 
     public void flushRows() throws IOException {
-        if (this.currentSheet instanceof SXSSFSheet) {
-            ((SXSSFSheet)this.currentSheet).flushRows();
+        if (this.currentSheet instanceof SXSSFSheet sheet) {
+            sheet.flushRows();
         } else {
             throw new UnsupportedOperationException("Could not release memory. This sheet is not SXSSFSheet's instance");
         }
     }
 
     public void trackColumnForAutoSizing(int columnNumber) {
-        if (this.currentSheet instanceof SXSSFSheet) {
-            ((SXSSFSheet)this.currentSheet).trackColumnForAutoSizing(columnNumber - 1);
+        if (this.currentSheet instanceof SXSSFSheet sheet) {
+            sheet.trackColumnForAutoSizing(columnNumber - 1);
         } else {
             throw new UnsupportedOperationException("This function available only for SXSSFSheet sheet");
         }
     }
 
     public void untrackColumnForAutoSizing(int columnNumber) {
-        if (this.currentSheet instanceof SXSSFSheet) {
-            ((SXSSFSheet)this.currentSheet).untrackColumnForAutoSizing(columnNumber - 1);
+        if (this.currentSheet instanceof SXSSFSheet sheet) {
+            sheet.untrackColumnForAutoSizing(columnNumber - 1);
         } else {
             throw new UnsupportedOperationException("This function available only for SXSSFSheet sheet");
         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelSheet.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/ExcelSheet.java
@@ -163,8 +163,8 @@ public class ExcelSheet {
     public ExcelCell getCellByHeaderName(int rowNumber, String headerName, int startIndex) {
         this.validateRowIndex(rowNumber, true);
         List<Integer> indexes = this.getHeaderIndexesByName(headerName, startIndex);
-        if (!indexes.isEmpty() && indexes.get(0) != -1) {
-            return this.getRow(rowNumber).getCell(indexes.get(0));
+        if (!indexes.isEmpty() && indexes.getFirst() != -1) {
+            return this.getRow(rowNumber).getCell(indexes.getFirst());
         } else {
             String basicMessage = "Error during operation with headers. Excel file name is '%s', excel sheet name is '%s'. Header row index = %s".formatted(this.getExcelBookName(), this.getSheetName(), this.headerRowIndex);
             if (this.getHeaderRowIndex() <= -1) {
@@ -203,8 +203,7 @@ public class ExcelSheet {
                 ExcelCell cell = (ExcelCell) o;
                 String cellValue = cell.getValue();
 
-                for (int i = 0; i < content.length; ++i) {
-                    String contentVal = content[i];
+                for (String contentVal : content) {
                     if (StringUtils.equalsIgnoreCase(cellValue, contentVal)) {
                         if (StringUtils.isNotEmpty(cellValue)) {
                             ++valuesCount;
@@ -284,7 +283,7 @@ public class ExcelSheet {
     }
 
     public Iterator<ExcelRow> iterator() {
-        return new Iterator<ExcelRow>() {
+        return new Iterator<>() {
             int index = 1;
             final int endIndex = ExcelSheet.this.getMaxRowNum();
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/exceptions/InvalidFormatOfSourceException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/exceptions/InvalidFormatOfSourceException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 package org.qubership.atp.adapter.excel.exceptions;
 
+import java.io.Serial;
+
 public class InvalidFormatOfSourceException extends Exception {
-    private static final long serialVersionUID = 4514727182318431839L;
+  @Serial
+  private static final long serialVersionUID = 4514727182318431839L;
 
     public InvalidFormatOfSourceException(String message, Object... params) {
-        this(String.format(message, params));
+        this(message.formatted(params));
     }
 
     public InvalidFormatOfSourceException(String message) {
@@ -28,7 +31,7 @@ public class InvalidFormatOfSourceException extends Exception {
     }
 
     public InvalidFormatOfSourceException(Throwable cause, String message, Object... params) {
-        this(String.format(message, params), cause);
+        this(message.formatted(params), cause);
     }
 
     public InvalidFormatOfSourceException(String message, Throwable cause) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/exceptions/RecordingInFileException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/excel/exceptions/RecordingInFileException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package org.qubership.atp.adapter.excel.exceptions;
 
 import java.io.IOException;
+import java.io.Serial;
 
 public class RecordingInFileException extends IOException {
-    private static final long serialVersionUID = 4514727182318431839L;
+  @Serial
+  private static final long serialVersionUID = 4514727182318431839L;
 
     public RecordingInFileException(String message, Throwable cause) {
         super(message, cause);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,12 +17,10 @@
 package org.qubership.atp.adapter.executor.executor;
 
 import static org.qubership.atp.adapter.report.WebReportItem.CloseSection;
-import static org.qubership.atp.adapter.report.WebReportItem.Message;
 import static org.qubership.atp.adapter.report.WebReportItem.OpenLog;
 import static org.qubership.atp.adapter.report.WebReportItem.OpenSection;
 
 import org.apache.log4j.Level;
-
 import org.qubership.atp.adapter.executor.executor.items.BvMessageItem;
 import org.qubership.atp.adapter.executor.executor.items.CreateContextItem;
 import org.qubership.atp.adapter.executor.executor.items.ItfOpenSectionItem;
@@ -44,26 +42,21 @@ public class AtpRamWriterAdapter implements ReportAdapter {
 
     @Override
     public void write(ReportWriter wr, Object item) {
-        if (wr instanceof AtpRamWriterWraper) {
-            AtpRamWriter writer = ((AtpRamWriterWraper) wr).getAtpRamWriter();
-            if (item instanceof OpenLog) {
-                OpenLog i = (OpenLog) item;
+        if (wr instanceof AtpRamWriterWraper wrapper) {
+            AtpRamWriter writer = wrapper.getAtpRamWriter();
+            if (item instanceof OpenLog i) {
                 writer.openLog(i.getLogName(), i.getDescription());
             }
-            if (item instanceof CreateContextItem) {
-                CreateContextItem i = (CreateContextItem) item;
+            if (item instanceof CreateContextItem i) {
                 writer.createContext(i.getTestRunId());
             }
-            if (item instanceof CloseLog) {
-                CloseLog i = (CloseLog) item;
+            if (item instanceof CloseLog i) {
                 writer.closeLog(i);
             }
-            if (item instanceof OpenSection) {
-                OpenSection i = (OpenSection) item;
+            if (item instanceof OpenSection i) {
                 writer.openSection(i);
             }
-            if (item instanceof Message) {
-                WebReportItem.Message msg = (WebReportItem.Message) item;
+            if (item instanceof WebReportItem.Message msg) {
                 StringBuilder sb = new StringBuilder();
                 String message = msg.getMessage();
                 if (message != null) {
@@ -80,45 +73,34 @@ public class AtpRamWriterAdapter implements ReportAdapter {
 
                 writer.message(title, level, message1, page);
             }
-            if (item instanceof CloseSection) {
-                CloseSection i = (CloseSection) item;
+            if (item instanceof CloseSection i) {
                 writer.closeSection(i);
             }
-            if (item instanceof UiMessageItem) {
-                UiMessageItem i = (UiMessageItem) item;
+            if (item instanceof UiMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof TechMessageItem) {
-                TechMessageItem i = (TechMessageItem) item;
+            if (item instanceof TechMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof ItfOpenSectionItem) {
-                ItfOpenSectionItem i = (ItfOpenSectionItem) item;
+            if (item instanceof ItfOpenSectionItem i) {
                 i.openSection(writer);
             }
-            if (item instanceof BvMessageItem) {
-                BvMessageItem i = (BvMessageItem) item;
+            if (item instanceof BvMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof RestMessageItem) {
-                RestMessageItem i = (RestMessageItem) item;
+            if (item instanceof RestMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof MiaOpenSectionItem) {
-                MiaOpenSectionItem i = (MiaOpenSectionItem) item;
+            if (item instanceof MiaOpenSectionItem i) {
                 i.openSection(writer);
             }
-            if (item instanceof SqlMessageItem) {
-                SqlMessageItem i = (SqlMessageItem) item;
+            if (item instanceof SqlMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof SshMessageItem) {
-                SshMessageItem i = (SshMessageItem) item;
+            if (item instanceof SshMessageItem i) {
                 i.message(writer);
             }
-            if (item instanceof ActionMessage) {
-                //needed to support screenshot
-                ActionMessage msg = (ActionMessage)item;
+            if (item instanceof ActionMessage msg) {
                 StringBuilder sb = new StringBuilder();
                 String message = msg.getMessage();
                 if (message != null) {
@@ -130,8 +112,6 @@ public class AtpRamWriterAdapter implements ReportAdapter {
                 SourceProvider page = msg.getPage();
                 writer.message(title, level, message1, page);
             }
-
-
         }
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/RamReport.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/RamReport.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.annotation.Nullable;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
 import org.qubership.atp.adapter.common.context.TestRunContext;
@@ -41,6 +39,8 @@ import org.qubership.atp.ram.models.BrowserConsoleLogsTable;
 import org.qubership.atp.ram.models.logrecords.parts.Request;
 import org.qubership.atp.ram.models.logrecords.parts.Response;
 import org.qubership.atp.ram.models.logrecords.parts.ValidationTable;
+
+import jakarta.annotation.Nullable;
 
 public class RamReport {
     protected static Report report;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/utils/AttachmentCreator.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/executor/executor/utils/AttachmentCreator.java
@@ -107,8 +107,8 @@ public class AttachmentCreator {
 
     private static void createFileMetadata(SourceProvider sourceProvider, String fileName, NttAttachment attachment) {
         FileMetadata fileMetadata;
-        if (sourceProvider instanceof ExtendedFileSourceProvider) {
-            fileMetadata = ((ExtendedFileSourceProvider) sourceProvider).getFileMetadata();
+        if (sourceProvider instanceof ExtendedFileSourceProvider provider) {
+            fileMetadata = provider.getFileMetadata();
         } else {
             fileMetadata = new FileMetadata(FileType.COMMON, fileName);
         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ActionCreatingException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ActionCreatingException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.qubership.atp.adapter.keyworddriven;
 
+import java.io.Serial;
+
 public class ActionCreatingException extends Exception {
-    private static final long serialVersionUID = -8017013044911600635L;
+  @Serial
+  private static final long serialVersionUID = -8017013044911600635L;
 
     public ActionCreatingException(Throwable e) {
         super(e);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ActionsFactory.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ActionsFactory.java
@@ -34,7 +34,7 @@ public class ActionsFactory {
 
         if (!actions.containsKey(actionClass)) {
             try {
-                actions.put(actionClass, actionClass.newInstance());
+                actions.put(actionClass, actionClass.getDeclaredConstructor().newInstance());
             } catch (Throwable var3) {
                 Throwable e = var3;
                 throw new ActionCreatingException(e);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/InvalidFormatOfSourceException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/InvalidFormatOfSourceException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 package org.qubership.atp.adapter.keyworddriven;
 
+import java.io.Serial;
+
 public class InvalidFormatOfSourceException extends Exception {
-    private static final long serialVersionUID = 4514727182318431839L;
+  @Serial
+  private static final long serialVersionUID = 4514727182318431839L;
 
     public InvalidFormatOfSourceException(String message, Object... params) {
-        this(String.format(message, params));
+        this(message.formatted(params));
     }
 
     public InvalidFormatOfSourceException(String message) {
@@ -28,7 +31,7 @@ public class InvalidFormatOfSourceException extends Exception {
     }
 
     public InvalidFormatOfSourceException(Throwable cause, String message, Object... params) {
-        this(String.format(message, params), cause);
+        this(message.formatted(params), cause);
     }
 
     public InvalidFormatOfSourceException(String message, Throwable cause) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ParametersHandlerException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/ParametersHandlerException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.qubership.atp.adapter.keyworddriven;
 
+import java.io.Serial;
+
 public class ParametersHandlerException extends Exception {
-    private static final long serialVersionUID = 1L;
+  @Serial
+  private static final long serialVersionUID = 1L;
 
     public ParametersHandlerException(String message, Throwable cause) {
         super(message, cause);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/TestCaseException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/TestCaseException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 package org.qubership.atp.adapter.keyworddriven;
 
+import java.io.Serial;
+
 import org.qubership.atp.adapter.keyworddriven.executable.Keyword;
 import org.qubership.atp.adapter.keyworddriven.executor.KeywordExecutor;
 
 public class TestCaseException extends Exception {
-    private static final long serialVersionUID = -7935665405480044065L;
+  @Serial
+  private static final long serialVersionUID = -7935665405480044065L;
     private final Keyword keyword = KeywordExecutor.getKeyword();
 
     public TestCaseException() {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatParametersReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatParametersReader.java
@@ -43,7 +43,7 @@ public class BasicFormatParametersReader extends ExcelParametersReader {
     public void loadParameters(Section section) throws InvalidFormatOfSourceException {
         if (!StringUtils.isEmpty(this.sheetName)) {
             if (!this.excelBook.hasSheet(this.sheetName)) {
-                throw new InvalidFormatOfSourceException(String.format("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s", this.sheetName, this.excelBook.getCurrentFile(), this.excelBook.getAllSheets()));
+                throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s".formatted(this.sheetName, this.excelBook.getCurrentFile(), this.excelBook.getAllSheets()));
             }
 
             try {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -53,7 +52,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     @Deprecated
     public static final String DEFAULT_DATE_FORMAT = Config.getString("var.format.date.mask", "yyyy-MM-dd HH:mm:ss");
     public static final TimeZone DATE_FORMAT_TIMEZONE;
-    private static Log log;
+    private static final Log log;
     public static final String TEST_CASE_BASIC_FOLDER;
     public static final String TEST_CASE_MAIN_SHEET;
     public static final String YES;
@@ -69,8 +68,8 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     private static final DateFormat dateFormat;
     private static final PatternLayout appenderLayout;
     private static final String LOG_NAME = "logs/%s-%s.log";
-    private ExcelSheet excelSheet;
-    private List<Integer> sectionHeaderIndexes;
+    private final ExcelSheet excelSheet;
+    private final List<Integer> sectionHeaderIndexes;
 
     public BasicFormatTestCaseReader(String fileName) throws InvalidFormatOfSourceException {
         this(KDTUtils.checkCriticalFileExistAndExit(TEST_CASE_BASIC_FOLDER, fileName));
@@ -81,23 +80,21 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     }
 
     public BasicFormatTestCaseReader(ExcelSheet excelSheet) {
-        this.sectionHeaderIndexes = new ArrayList();
+        this.sectionHeaderIndexes = new ArrayList<>();
         this.excelSheet = excelSheet;
     }
 
     public BasicFormatTestCaseReader(ExcelBook excelBook) throws InvalidFormatOfSourceException {
-        this.sectionHeaderIndexes = new ArrayList();
+        this.sectionHeaderIndexes = new ArrayList<>();
         if (!excelBook.hasSheet(TEST_CASE_MAIN_SHEET)) {
             throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s".formatted(TEST_CASE_MAIN_SHEET, excelBook.getCurrentFile(), excelBook.getAllSheets()));
         } else {
             try {
                 this.excelSheet = new ExcelSheet(excelBook, TEST_CASE_MAIN_SHEET, 1, this.getHeaders());
                 ExcelUtils.checkHeaders(this.excelSheet, this.getHeaders());
-            } catch (org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException var3) {
-                org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException e = var3;
+            } catch (org.qubership.atp.adapter.excel.exceptions.InvalidFormatOfSourceException e) {
                 throw new InvalidFormatOfSourceException(e.getMessage(), e);
             }
-
             this.sectionHeaderIndexes.addAll(this.excelSheet.getHeaderIndexesByName(SECTION_COLUMN_NAME));
         }
     }
@@ -107,10 +104,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
         FileTestCase testCase = (FileTestCase)tc;
         this.setLogger(testCase);
         if (!testCase.getExecutableSectionName().isEmpty()) {
-            Iterator var3 = testCase.getExecutableSectionName().iterator();
-
-            while(var3.hasNext()) {
-                String sectionName = (String)var3.next();
+            for (String sectionName : testCase.getExecutableSectionName()) {
                 this.loadSection(testCase, this.excelSheet, sectionName);
             }
         } else {
@@ -139,55 +133,51 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
             int firstIndex = 0;
             int lastIndex = 0;
             int rowsCount = excelSheet.getRowList().size();
-            Iterator var7 = this.sectionHeaderIndexes.iterator();
-
-            while(var7.hasNext()) {
-                Integer sectionIndex = (Integer)var7.next();
-
-                for(int currentRowNum = excelSheet.getHeaderRowIndex() + 1; currentRowNum <= rowsCount && excelSheet.getRow(currentRowNum) != null; ++currentRowNum) {
+            for (Integer sectionIndex : this.sectionHeaderIndexes) {
+                for (int currentRowNum = excelSheet.getHeaderRowIndex() + 1; currentRowNum <= rowsCount && excelSheet.getRow(currentRowNum) != null; ++currentRowNum) {
                     boolean isCurrentRowMatches = excelSheet.getCurrentRow().getCell(sectionIndex).getValue().equalsIgnoreCase(sectionName);
                     if (isCurrentRowMatches) {
                         if (firstIndex == 0) {
                             firstIndex = excelSheet.getCurrentRow().getRowNum();
                             lastIndex = firstIndex - 1;
                         }
-
                         ++lastIndex;
                     }
-
                     if (firstIndex != 0 && !isCurrentRowMatches || isCurrentRowMatches && excelSheet.getCurrentRow().getRowNum() == excelSheet.getMaxRowNum()) {
                         this.loadSubSection(testCase, firstIndex, -1, excelSheet, lastIndex + 1);
                         return;
                     }
                 }
             }
-
             log.error("Section '%s' not found".formatted(sectionName));
         }
     }
 
     private boolean hasSubSections(int headerIndex, int rowNum) {
         if (headerIndex + 1 < this.sectionHeaderIndexes.size()) {
-            return this.excelSheet.getRow(rowNum).getCell((Integer)this.sectionHeaderIndexes.get(headerIndex + 1)).getValue().length() > 0;
+            return !this.excelSheet.getRow(rowNum).getCell(this.sectionHeaderIndexes.get(headerIndex + 1)).getValue().isEmpty();
         } else {
             return false;
         }
     }
 
     private boolean hasRunnable(int headerIndex, int rowNum) {
-        String sectionName = this.excelSheet.getRow(rowNum).getCell((Integer)this.sectionHeaderIndexes.get(headerIndex)).getValue();
+        String sectionName = this.excelSheet.getRow(rowNum).getCell(this.sectionHeaderIndexes.get(headerIndex)).getValue();
 
         ExcelRow row;
-        for(String currentSectionName = sectionName; rowNum <= this.excelSheet.getMaxRowNum() && StringUtils.isNotBlank(currentSectionName) && sectionName.equalsIgnoreCase(currentSectionName); currentSectionName = row == null ? null : row.getCell((Integer)this.sectionHeaderIndexes.get(headerIndex)).getValue()) {
-            String runValue = this.excelSheet.getRow(rowNum).getCell((Integer)this.excelSheet.getHeaderIndexesByName(RUN_COLUMN_NAME).get(0)).getValue();
+        for(String currentSectionName = sectionName;
+            rowNum <= this.excelSheet.getMaxRowNum()
+                    && StringUtils.isNotBlank(currentSectionName)
+                    && sectionName.equalsIgnoreCase(currentSectionName);
+            currentSectionName = row == null
+                    ? null : row.getCell(this.sectionHeaderIndexes.get(headerIndex)).getValue()) {
+            String runValue = this.excelSheet.getRow(rowNum).getCell(this.excelSheet.getHeaderIndexesByName(RUN_COLUMN_NAME).getFirst()).getValue();
             if (YES.equalsIgnoreCase(runValue)) {
                 return true;
             }
-
             ++rowNum;
             row = rowNum <= this.excelSheet.getMaxRowNum() ? this.excelSheet.getRow(rowNum) : null;
         }
-
         return false;
     }
 
@@ -199,9 +189,11 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
             for(int currentRowNum = rowNum; currentRowNum < endRow; ++currentRowNum) {
                 subSheet.setCurrentRow(subSheet.getRow(currentRowNum));
                 int nextHeaderIndex = headerIndex + 1;
-                String parentName = headerIndex == -1 ? parent.getName() : subSheet.getCurrentRow().getCell((Integer)this.sectionHeaderIndexes.get(headerIndex)).getValue();
-                String name = subSheet.getCurrentRow().getCell((Integer)this.sectionHeaderIndexes.get(nextHeaderIndex)).getValue();
-                if (parentName.equals(parent.getName()) && name.length() > 0) {
+                String parentName = headerIndex == -1
+                        ? parent.getName()
+                        : subSheet.getCurrentRow().getCell(this.sectionHeaderIndexes.get(headerIndex)).getValue();
+                String name = subSheet.getCurrentRow().getCell(this.sectionHeaderIndexes.get(nextHeaderIndex)).getValue();
+                if (parentName.equals(parent.getName()) && !name.isEmpty()) {
                     isChildrenFound = true;
                     boolean hasChildren = this.hasSubSections(nextHeaderIndex, currentRowNum);
                     boolean hasRunnables = this.hasRunnable(nextHeaderIndex, currentRowNum);
@@ -218,7 +210,12 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
                         if (hasChildren) {
                             this.loadSubSection(section, currentRowNum, nextHeaderIndex, subSheet, endRow);
                         } else {
-                            section.setDescription((Integer)subSheet.getHeaderIndexesByName(DESCRIPTION_COLUMN_NAME).get(0) >= 0 ? subSheet.getCellByHeaderName(subSheet.getCurrentRow().getRowNum(), DESCRIPTION_COLUMN_NAME, (Integer)this.sectionHeaderIndexes.get(nextHeaderIndex)).getValue() : name);
+                            section.setDescription(
+                                    subSheet.getHeaderIndexesByName(DESCRIPTION_COLUMN_NAME).getFirst() >= 0
+                                            ? subSheet.getCellByHeaderName(subSheet.getCurrentRow().getRowNum(),
+                                            DESCRIPTION_COLUMN_NAME,
+                                            this.sectionHeaderIndexes.get(nextHeaderIndex)).getValue()
+                                            : name);
                             this.loadKeywords(section, subSheet);
                         }
                     }
@@ -232,7 +229,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
 
     protected void loadKeywords(SectionImpl parent, ExcelSheet sheet) throws InvalidFormatOfSourceException {
         String keywordsSheet = ExcelUtils.getCellValue(sheet, KEYWORDS_COLUMN_NAME);
-        if (keywordsSheet.length() != 0) {
+        if (!keywordsSheet.isEmpty()) {
             BasicFormatReaderFactory.getInstance().newKeywordsReader(sheet.getExcelBook(), keywordsSheet).readKeywords(parent);
         }
     }
@@ -244,7 +241,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     }
 
     protected void loadParametersFromAllTabs(Section section, ExcelSheet testCaseSheet) throws InvalidFormatOfSourceException {
-        Set<String> processedTabs = new HashSet();
+        Set<String> processedTabs = new HashSet<>();
 
         for(int index = this.excelSheet.getHeaderRowIndex() + 1; index < this.excelSheet.getMaxRowNum() + 1; ++index) {
             testCaseSheet.setCurrentRow(testCaseSheet.getRow(index));
@@ -272,7 +269,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
 
     static {
         String timeZoneId = Config.getString("var.format.date.timezone");
-        DATE_FORMAT_TIMEZONE = timeZoneId.length() == 0 ? TimeZone.getDefault() : TimeZone.getTimeZone(timeZoneId);
+        DATE_FORMAT_TIMEZONE = timeZoneId.isEmpty() ? TimeZone.getDefault() : TimeZone.getTimeZone(timeZoneId);
         log = LogFactory.getLog(BasicFormatTestCaseReader.class);
         TEST_CASE_BASIC_FOLDER = Config.getString("BasicFormatTestCaseReader.TEST_CASE_BASIC_FOLDER", BasicFormatTestSuiteReader.TEST_SUITE_BASIC_FOLDER);
         TEST_CASE_MAIN_SHEET = Config.getString("BasicFormatTestCaseReader.TEST_CASE_MAIN_SHEET", "Test Case");

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,25 @@
 
 package org.qubership.atp.adapter.keyworddriven.basicformat;
 
+import java.io.File;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 import org.qubership.atp.adapter.excel.ExcelBook;
 import org.qubership.atp.adapter.excel.ExcelRow;
 import org.qubership.atp.adapter.excel.ExcelSheet;
@@ -28,24 +47,6 @@ import org.qubership.atp.adapter.keyworddriven.executable.TestCase;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.KDTUtils;
 import org.qubership.atp.adapter.utils.excel.ExcelUtils;
-import java.io.File;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
 
 public class BasicFormatTestCaseReader implements TestCaseReader {
     /** @deprecated */
@@ -87,7 +88,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     public BasicFormatTestCaseReader(ExcelBook excelBook) throws InvalidFormatOfSourceException {
         this.sectionHeaderIndexes = new ArrayList();
         if (!excelBook.hasSheet(TEST_CASE_MAIN_SHEET)) {
-            throw new InvalidFormatOfSourceException(String.format("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s", TEST_CASE_MAIN_SHEET, excelBook.getCurrentFile(), excelBook.getAllSheets()));
+            throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s".formatted(TEST_CASE_MAIN_SHEET, excelBook.getCurrentFile(), excelBook.getAllSheets()));
         } else {
             try {
                 this.excelSheet = new ExcelSheet(excelBook, TEST_CASE_MAIN_SHEET, 1, this.getHeaders());
@@ -122,7 +123,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
     }
 
     private void setLogger(FileTestCase testCase) {
-        String logFileName = String.format("logs/%s-%s.log", testCase.getName(), dateFormat.format(new Date()));
+        String logFileName = "logs/%s-%s.log".formatted(testCase.getName(), dateFormat.format(new Date()));
         FileAppender appender = new FileAppender(appenderLayout, logFileName, false);
 
         Logger logger = Logger.getLogger(testCase.getName());
@@ -133,7 +134,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
 
     private void loadSection(FileTestCase testCase, ExcelSheet excelSheet, String sectionName) throws InvalidFormatOfSourceException {
         if (StringUtils.isBlank(sectionName)) {
-            log.error(String.format("Section is blank in %s test case", testCase.getName()));
+            log.error("Section is blank in %s test case".formatted(testCase.getName()));
         } else {
             int firstIndex = 0;
             int lastIndex = 0;
@@ -161,7 +162,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
                 }
             }
 
-            log.error(String.format("Section '%s' not found", sectionName));
+            log.error("Section '%s' not found".formatted(sectionName));
         }
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
@@ -188,7 +188,7 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
 
     private void loadSubSection(Executable parent, int rowNum, int headerIndex, ExcelSheet subSheet, int endRow) throws InvalidFormatOfSourceException {
         if (this.sectionHeaderIndexes.size() > headerIndex + 1) {
-            String previos = "";
+            String previous = "";
             boolean isChildrenFound = false;
 
             for(int currentRowNum = rowNum; currentRowNum < endRow; ++currentRowNum) {
@@ -202,8 +202,8 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
                     isChildrenFound = true;
                     boolean hasChildren = this.hasSubSections(nextHeaderIndex, currentRowNum);
                     boolean hasRunnables = this.hasRunnable(nextHeaderIndex, currentRowNum);
-                    if (!previos.equals(name)) {
-                        previos = name;
+                    if (!previous.equals(name)) {
+                        previous = name;
                     } else if (hasChildren) {
                         continue;
                     }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestCaseReader.java
@@ -17,6 +17,7 @@
 package org.qubership.atp.adapter.keyworddriven.basicformat;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -118,7 +119,11 @@ public class BasicFormatTestCaseReader implements TestCaseReader {
 
     private void setLogger(FileTestCase testCase) {
         String logFileName = "logs/%s-%s.log".formatted(testCase.getName(), dateFormat.format(new Date()));
-        FileAppender appender = new FileAppender(appenderLayout, logFileName, false);
+        try {
+            FileAppender appender = new FileAppender(appenderLayout, logFileName, false);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         Logger logger = Logger.getLogger(testCase.getName());
 //        logger.addAppender(appender);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestSuiteReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/BasicFormatTestSuiteReader.java
@@ -68,7 +68,7 @@ public class BasicFormatTestSuiteReader implements TestSuiteReader {
 
     public BasicFormatTestSuiteReader(ExcelBook excelBook) throws InvalidFormatOfSourceException {
         if (!excelBook.hasSheet(TEST_SUITE_MAIN_SHEET)) {
-            throw new InvalidFormatOfSourceException(String.format("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s", TEST_SUITE_MAIN_SHEET, excelBook.getCurrentFile(), excelBook.getAllSheets()));
+            throw new InvalidFormatOfSourceException("Sheet '%s' hasn't been found in the '%s' WB. Available sheets are: %s".formatted(TEST_SUITE_MAIN_SHEET, excelBook.getCurrentFile(), excelBook.getAllSheets()));
         } else {
             try {
                 this.excelSheet = new ExcelSheet(excelBook, TEST_SUITE_MAIN_SHEET, 1, this.getHeaders());

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/Filter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/Filter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.qubership.atp.adapter.keyworddriven.basicformat;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.qubership.atp.adapter.keyworddriven.executable.Executable;
 import org.qubership.atp.adapter.keyworddriven.executable.Section;
 import org.qubership.atp.adapter.keyworddriven.executor.KeywordExecutor;
-import org.apache.commons.lang3.ArrayUtils;
 
 public abstract class Filter<T> {
     private Filter() {
@@ -64,7 +64,7 @@ public abstract class Filter<T> {
             public boolean match(T section) {
                 int level = section.getValidationLevel();
                 if (level > KeywordExecutor.validationLevel) {
-                    section.log().debug(String.format("Section '%s' was skipped because validation level of it is bigger than execution level (%d > %d)", section.getName(), level, KeywordExecutor.validationLevel));
+                    section.log().debug("Section '%s' was skipped because validation level of it is bigger than execution level (%d > %d)".formatted(section.getName(), level, KeywordExecutor.validationLevel));
                     return false;
                 } else {
                     return true;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/Filter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/Filter.java
@@ -28,23 +28,19 @@ public abstract class Filter<T> {
     public static <T> Filter or(final Filter<T>... filters) {
         return new Filter<T>() {
             public boolean match(T object) {
-                Filter[] var2 = filters;
-                int var3 = var2.length;
-
-                for(int var4 = 0; var4 < var3; ++var4) {
-                    Filter<T> filter = var2[var4];
+                for(int var4 = 0; var4 < filters.length; ++var4) {
+                    Filter<T> filter = ((Filter[]) filters)[var4];
                     if (filter.match(object)) {
                         return true;
                     }
                 }
-
                 return false;
             }
         };
     }
 
     public static <T extends Executable> Filter<T> executableByName(final String... names) {
-        return new Filter<T>() {
+        return new Filter<>() {
             public boolean match(T executable) {
                 return ArrayUtils.contains(names, executable.getName());
             }
@@ -52,7 +48,7 @@ public abstract class Filter<T> {
     }
 
     public static <T> Filter<T> noFilter() {
-        return new Filter<T>() {
+        return new Filter<>() {
             public boolean match(T o) {
                 return true;
             }
@@ -60,7 +56,7 @@ public abstract class Filter<T> {
     }
 
     public static <T extends Section> Filter<T> filterSectionByValidationLevel() {
-        return new Filter<T>() {
+        return new Filter<>() {
             public boolean match(T section) {
                 int level = section.getValidationLevel();
                 if (level > KeywordExecutor.validationLevel) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/TestSuiteTextReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/TestSuiteTextReader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,15 @@
 
 package org.qubership.atp.adapter.keyworddriven.basicformat;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.qubership.atp.adapter.keyworddriven.InvalidFormatOfSourceException;
 import org.qubership.atp.adapter.keyworddriven.executable.Executable;
 import org.qubership.atp.adapter.keyworddriven.executable.FileTestCase;
@@ -23,14 +32,6 @@ import org.qubership.atp.adapter.keyworddriven.executable.TestCase;
 import org.qubership.atp.adapter.keyworddriven.executable.TestSuite;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.KDTUtils;
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 public class TestSuiteTextReader implements TestSuiteReader {
     private static Log log = LogFactory.getLog(TestSuiteTextReader.class);
@@ -123,7 +124,7 @@ public class TestSuiteTextReader implements TestSuiteReader {
 
     public List<TestCase> parserList(Executable parent) throws InvalidFormatOfSourceException {
         if (this.lst == null) {
-            throw new InvalidFormatOfSourceException(String.format("No strings read from file. May be file does not exist / file structure is wrong? File name: %s", this.fileLocation));
+            throw new InvalidFormatOfSourceException("No strings read from file. May be file does not exist / file structure is wrong? File name: %s".formatted(this.fileLocation));
         } else {
             List<TestCase> listCases = new ArrayList();
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/TestSuiteTextReader.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/basicformat/TestSuiteTextReader.java
@@ -34,14 +34,14 @@ import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.KDTUtils;
 
 public class TestSuiteTextReader implements TestSuiteReader {
-    private static Log log = LogFactory.getLog(TestSuiteTextReader.class);
-    private static String TEST_SUITE_WORD = Config.getString("user.testsuite.name", "Test Suite:");
-    private static String TEST_CASE_WORD = Config.getString("user.testcase.name", "Test Case:");
-    private static String TEST_PARAMETERS_WORD = Config.getString("user.parameters.name", "Parameters:");
-    private static String TEST_KEYWORD_WORD = Config.getString("user.keyword.name", "Keyword:");
-    private static String TEST_DATA_SET_WORD = Config.getString("user.dataset.name", "Data Set:");
-    private List<String> lst = new ArrayList();
-    private List<TestCase> listTestCases = new ArrayList();
+    private static final Log log = LogFactory.getLog(TestSuiteTextReader.class);
+    private static final String TEST_SUITE_WORD = Config.getString("user.testsuite.name", "Test Suite:");
+    private static final String TEST_CASE_WORD = Config.getString("user.testcase.name", "Test Case:");
+    private static final String TEST_PARAMETERS_WORD = Config.getString("user.parameters.name", "Parameters:");
+    private static final String TEST_KEYWORD_WORD = Config.getString("user.keyword.name", "Keyword:");
+    private static final String TEST_DATA_SET_WORD = Config.getString("user.dataset.name", "Data Set:");
+    private List<String> lst = new ArrayList<>();
+    private List<TestCase> listTestCases = new ArrayList<>();
     private String fileLocation = "";
     private String fileName = "";
 
@@ -129,12 +129,12 @@ public class TestSuiteTextReader implements TestSuiteReader {
             List<TestCase> listCases = new ArrayList();
 
             for(int i = 0; i < this.lst.size(); ++i) {
-                String currentLine = ((String)this.lst.get(i)).trim();
+                String currentLine = this.lst.get(i).trim();
                 if (currentLine.startsWith(TEST_SUITE_WORD)) {
                     String testSuiteName = currentLine.substring(currentLine.indexOf(":") + 1).trim();
                     parent.setName(testSuiteName);
                 } else if (currentLine.startsWith(TEST_CASE_WORD)) {
-                    List<String> tmpTC = new ArrayList();
+                    List<String> tmpTC = new ArrayList<>();
                     String tcName = currentLine.substring(currentLine.indexOf(":") + 1).trim();
                     FileTestCase testCase = new FileTestCase(tcName, "", this.fileLocation);
                     this.fillParameter(testCase);
@@ -142,7 +142,7 @@ public class TestSuiteTextReader implements TestSuiteReader {
                     String nameOfBlock = "";
 
                     for(int j = i; j < this.lst.size(); ++j) {
-                        String currentScenarioLine = ((String)this.lst.get(j)).trim();
+                        String currentScenarioLine = this.lst.get(j).trim();
                         if (currentScenarioLine.startsWith(TEST_DATA_SET_WORD)) {
                             isSpecialBlock = true;
                         } else if (currentScenarioLine.startsWith(TEST_PARAMETERS_WORD)) {
@@ -156,8 +156,8 @@ public class TestSuiteTextReader implements TestSuiteReader {
                             nameOfBlock = currentScenarioLine.substring(currentScenarioLine.indexOf(":") + 1).trim();
                         }
 
-                        if (currentScenarioLine.length() > 0) {
-                            if (currentScenarioLine.startsWith(TEST_CASE_WORD) && tmpTC.size() > 0 || j == this.lst.size() - 1) {
+                        if (!currentScenarioLine.isEmpty()) {
+                            if (currentScenarioLine.startsWith(TEST_CASE_WORD) && !tmpTC.isEmpty() || j == this.lst.size() - 1) {
                                 if (StringUtils.isNotBlank(currentScenarioLine) && !isSpecialBlock && nameOfBlock.equals(testCase.getName()) && !currentScenarioLine.startsWith(TEST_CASE_WORD)) {
                                     tmpTC.add(currentScenarioLine);
                                 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/ContextUtils.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/ContextUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ public class ContextUtils {
         Object value = Context.getValue(key);
         if (value == null) {
             return defaultValue;
-        } else if (value instanceof Integer) {
-            return (Integer)value;
+        } else if (value instanceof Integer integer) {
+            return integer;
         } else {
             try {
                 return Integer.parseInt(value.toString());
@@ -42,7 +42,7 @@ public class ContextUtils {
         if (value == null) {
             return defaultValue;
         } else {
-            return value instanceof Boolean ? (Boolean)value : Boolean.parseBoolean(value.toString());
+            return value instanceof Boolean b ? b : Boolean.parseBoolean(value.toString());
         }
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTContextDataStorageProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTContextDataStorageProvider.java
@@ -24,8 +24,8 @@ import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStoragePr
 import jakarta.annotation.Nullable;
 
 public class KDTContextDataStorageProvider implements ContextDataStorageProvider {
-    private static ThreadLocal<Executable> executable = new ThreadLocal();
-    private static KDTLocalContextDataStorage storage = new KDTLocalContextDataStorage();
+    private static final ThreadLocal<Executable> executable = new ThreadLocal<>();
+    private static final KDTLocalContextDataStorage storage = new KDTLocalContextDataStorage();
 
     public KDTContextDataStorageProvider() {
     }
@@ -35,7 +35,7 @@ public class KDTContextDataStorageProvider implements ContextDataStorageProvider
     }
 
     static Executable get() {
-        Executable e = (Executable)executable.get();
+        Executable e = executable.get();
         if (e == null) {
             e = KeywordExecutor.getKeyword();
         }
@@ -43,7 +43,7 @@ public class KDTContextDataStorageProvider implements ContextDataStorageProvider
         if (e == null) {
             throw new NullPointerException("Executable context is unknown. Executable should be defined in KeywordExecutor or in KDTContextDataStorageProvider.");
         } else {
-            return (Executable)e;
+            return e;
         }
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTContextDataStorageProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTContextDataStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ import org.qubership.atp.adapter.keyworddriven.executable.Executable;
 import org.qubership.atp.adapter.keyworddriven.executor.KeywordExecutor;
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorageProvider;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nullable;
 
 public class KDTContextDataStorageProvider implements ContextDataStorageProvider {
     private static ThreadLocal<Executable> executable = new ThreadLocal();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTLocalContextDataStorage.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTLocalContextDataStorage.java
@@ -16,7 +16,6 @@
 
 package org.qubership.atp.adapter.keyworddriven.context;
 
-import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collections;
@@ -37,7 +36,7 @@ import jakarta.annotation.Nullable;
 
 public class KDTLocalContextDataStorage implements ContextDataStorage {
     protected static final Map<Executable, ContextDataStorage> map = Collections.synchronizedMap(new WeakHashMap());
-    private EventBus eventBus = new EventBus();
+    private final EventBus eventBus = new EventBus();
 
     public KDTLocalContextDataStorage() {
     }
@@ -48,7 +47,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
 
     protected ContextDataStorage getStorage(Executable keyword) {
         synchronized(map) {
-            return (ContextDataStorage)map.computeIfAbsent(keyword, (k) -> {
+            return map.computeIfAbsent(keyword, (k) -> {
                 return new DefaultContextDataStorage();
             });
         }
@@ -68,7 +67,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
     }
 
     public <T> ContextRecord<T> putValue(@Nonnull final String key, @Nullable final T value) {
-        return (ContextRecord)this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, ContextRecord<T>>() {
+        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, ContextRecord<T>>() {
             @Nullable
             public ContextRecord<T> apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.putValue(key, value);
@@ -82,7 +81,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
 
     @Nullable
     public <T> T getValue(@Nonnull final String key) {
-        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, T>() {
+        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<>() {
             @Nullable
             public T apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.getValue(key);
@@ -103,7 +102,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
 
     @Nonnull
     public Map<String, Object> getValues() {
-        return (Map)this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, Map<String, Object>>() {
+        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, Map<String, Object>>() {
             @Nullable
             public Map<String, Object> apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.getValues();
@@ -112,7 +111,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
     }
 
     public <T> ContextRecord<T> putRecord(@Nonnull final String key, @Nonnull final ContextRecord<T> record) {
-        return (ContextRecord)this.get(KDTContextDataStorageProvider.get(), new Function<ContextDataStorage, ContextRecord<T>>() {
+        return this.get(KDTContextDataStorageProvider.get(), new Function<ContextDataStorage, ContextRecord<T>>() {
             @Nullable
             public ContextRecord<T> apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.putRecord(key, record);
@@ -136,7 +135,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
 
     @Nonnull
     public <T> ContextRecord<T> getRecord(@Nonnull final String key, @Nonnull final ContextRecord<T> defaultRecord) {
-        return (ContextRecord)this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, ContextRecord<T>>() {
+        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, ContextRecord<T>>() {
             @Nullable
             public ContextRecord<T> apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.getRecord(key, defaultRecord);
@@ -146,7 +145,7 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
 
     @Nonnull
     public Map<String, ContextRecord<?>> getRecords() {
-        return (Map)this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, Map<String, ContextRecord<?>>>() {
+        return this.get(KDTContextDataStorageProvider.get(), new com.google.common.base.Function<ContextDataStorage, Map<String, ContextRecord<?>>>() {
             @Nullable
             public Map<String, ContextRecord<?>> apply(@Nullable ContextDataStorage contextDataStorage) {
                 return contextDataStorage.getRecords();
@@ -167,11 +166,11 @@ public class KDTLocalContextDataStorage implements ContextDataStorage {
         return this.eventBus;
     }
 
-    public void writeExternal(ObjectOutput out) throws IOException {
+    public void writeExternal(ObjectOutput out) {
         throw new UnsupportedOperationException("writeExternal does not supported in KDT because no ATP integration here");
     }
 
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    public void readExternal(ObjectInput in) {
         throw new UnsupportedOperationException("readExternal does not supported in KDT because no ATP integration here");
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTLocalContextDataStorage.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/context/KDTLocalContextDataStorage.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,13 +16,6 @@
 
 package org.qubership.atp.adapter.keyworddriven.context;
 
-import com.google.common.eventbus.EventBus;
-import org.qubership.atp.adapter.keyworddriven.executable.Executable;
-import org.qubership.atp.adapter.tools.tacomponents.context.Context;
-import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
-import org.qubership.atp.adapter.tools.tacomponents.context.ContextRecord;
-import org.qubership.atp.adapter.tools.tacomponents.context.ContextType;
-import org.qubership.atp.adapter.tools.tacomponents.context.DefaultContextDataStorage;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
@@ -30,8 +23,17 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import org.qubership.atp.adapter.keyworddriven.executable.Executable;
+import org.qubership.atp.adapter.tools.tacomponents.context.Context;
+import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
+import org.qubership.atp.adapter.tools.tacomponents.context.ContextRecord;
+import org.qubership.atp.adapter.tools.tacomponents.context.ContextType;
+import org.qubership.atp.adapter.tools.tacomponents.context.DefaultContextDataStorage;
+
+import com.google.common.eventbus.EventBus;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public class KDTLocalContextDataStorage implements ContextDataStorage {
     protected static final Map<Executable, ContextDataStorage> map = Collections.synchronizedMap(new WeakHashMap());

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executable/ExecutableImpl.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executable/ExecutableImpl.java
@@ -103,8 +103,8 @@ public abstract class ExecutableImpl implements Executable {
     }
 
     public TestCase getTestCase() {
-        if (this instanceof TestCase) {
-            return (TestCase)this;
+        if (this instanceof TestCase case1) {
+            return case1;
         } else {
             return this.getParent() == null ? null : this.getParent().getTestCase();
         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/BeforeAfterTestSuiteExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/BeforeAfterTestSuiteExecutor.java
@@ -25,7 +25,6 @@ import org.qubership.atp.adapter.keyworddriven.resources.ResourceFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
-import jakarta.annotation.Nullable;
 
 public class BeforeAfterTestSuiteExecutor extends PooledTestSuiteExecutor {
     private static final Logger log = Logger.getLogger(PooledTestSuiteExecutor.class);
@@ -55,11 +54,7 @@ public class BeforeAfterTestSuiteExecutor extends PooledTestSuiteExecutor {
     }
 
     protected static Predicate<Executable> by(final TestCaseType testCaseType) {
-        return new Predicate<Executable>() {
-            public boolean apply(@Nullable Executable input) {
-                return testCaseType == TestCaseType.matches(input);
-            }
-        };
+        return input -> testCaseType == TestCaseType.matches(input);
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/BeforeAfterTestSuiteExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/BeforeAfterTestSuiteExecutor.java
@@ -16,8 +16,6 @@
 
 package org.qubership.atp.adapter.keyworddriven.executor;
 
-import javax.annotation.Nullable;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.qubership.atp.adapter.keyworddriven.basicformat.flags.TestCaseType;
@@ -27,6 +25,7 @@ import org.qubership.atp.adapter.keyworddriven.resources.ResourceFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+import jakarta.annotation.Nullable;
 
 public class BeforeAfterTestSuiteExecutor extends PooledTestSuiteExecutor {
     private static final Logger log = Logger.getLogger(PooledTestSuiteExecutor.class);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/KeywordExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/KeywordExecutor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
 
 package org.qubership.atp.adapter.keyworddriven.executor;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.qubership.atp.adapter.keyworddriven.TestCaseException;
 import org.qubership.atp.adapter.keyworddriven.basicformat.ValidationLevel;
 import org.qubership.atp.adapter.keyworddriven.dataitem.Processor;
@@ -29,10 +34,6 @@ import org.qubership.atp.adapter.keyworddriven.routing.Route;
 import org.qubership.atp.adapter.report.Report;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.KDTUtils;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Iterator;
-import java.util.LinkedList;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class KeywordExecutor extends SectionExecutor {
     private static final ThreadLocal<Keyword> currentKeyword = new ThreadLocal();
@@ -49,7 +50,7 @@ public class KeywordExecutor extends SectionExecutor {
         if (route == null) {
             Report.getReport().warn("No routes found for keyword: " + keyword);
             if (VALIDATE_SCENARIO && !this.skip(keyword)) {
-                KDTUtils.criticalMessAndExit(String.format("No routes found for keyword %s\nExecution is interrupted", keyword));
+                KDTUtils.criticalMessAndExit("No routes found for keyword %s\nExecution is interrupted".formatted(keyword));
             }
 
         } else {
@@ -76,7 +77,7 @@ public class KeywordExecutor extends SectionExecutor {
         Keyword keyword = (Keyword)executable;
         boolean skip = keyword.getValidationLevel() > validationLevel;
         if (skip && keyword.log().isDebugEnabled()) {
-            keyword.log().info(String.format("Keyword '%s' was skipped because validation level of it is bigger than execution level ( %s > %s )", keyword, keyword.getValidationLevel(), validationLevel));
+            keyword.log().info("Keyword '%s' was skipped because validation level of it is bigger than execution level ( %s > %s )".formatted(keyword, keyword.getValidationLevel(), validationLevel));
         }
 
         return skip;
@@ -146,8 +147,8 @@ public class KeywordExecutor extends SectionExecutor {
     protected static void routeNotFound(Keyword keyword) {
         String KEYWORD_WAS_SKIPPED_DESC = "Keyword was skipped because no matches found for it. Keyword : '%s'.\n<br/>Possible routes:<br/>\n";
         String KEYWORD_WAS_SKIPPED_TITLE = "Keyword '%s' was skipped";
-        String title = String.format("Keyword '%s' was skipped", keyword.getName());
-        String description = String.format("Keyword was skipped because no matches found for it. Keyword : '%s'.\n<br/>Possible routes:<br/>\n", keyword.getDataItems());
+        String title = "Keyword '%s' was skipped".formatted(keyword.getName());
+        String description = "Keyword was skipped because no matches found for it. Keyword : '%s'.\n<br/>Possible routes:<br/>\n".formatted(keyword.getDataItems());
 
         Route route;
         for(Iterator var5 = KeywordRouteTable.getRoutesByName(keyword.getName()).iterator(); var5.hasNext(); description = description + route.getRouteItems() + "\n<br/>") {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/KeywordExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/KeywordExecutor.java
@@ -36,7 +36,7 @@ import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.KDTUtils;
 
 public class KeywordExecutor extends SectionExecutor {
-    private static final ThreadLocal<Keyword> currentKeyword = new ThreadLocal();
+    private static final ThreadLocal<Keyword> currentKeyword = new ThreadLocal<>();
     public static final boolean VALIDATE_SCENARIO = Boolean.parseBoolean(Config.getString("kdt.validate.scenarios"));
     public static final int SEVERITY_LEVEL = Integer.parseInt(Config.getString("kdt.severity.level", "0"));
     public static int validationLevel = ValidationLevel.parseValidationLevel(Config.getString("kdt.validation.level"));
@@ -92,18 +92,16 @@ public class KeywordExecutor extends SectionExecutor {
         } else {
             try {
                 keyword.getRoute().getActionExecutor().execute(keyword);
-            } catch (InvocationTargetException var3) {
-                InvocationTargetException e = var3;
+            } catch (InvocationTargetException e) {
                 this.throwTCE(keyword, e.getTargetException());
             } catch (Exception e) {
-                Report.getReport().error((String)null, "Error during keyword execution: " + keyword + ":" + e.getMessage(), new KDTUtils.StringSource(ExceptionUtils.getStackTrace(e)));
+                Report.getReport().error(null, "Error during keyword execution: " + keyword + ":" + e.getMessage(), new KDTUtils.StringSource(ExceptionUtils.getStackTrace(e)));
                 this.throwTCE(keyword, e);
             }
 
-            if (keyword.getChildren().size() > 0) {
+            if (!keyword.getChildren().isEmpty()) {
                 super.execute(keyword);
             }
-
         }
     }
 
@@ -111,15 +109,11 @@ public class KeywordExecutor extends SectionExecutor {
         LinkedList<DataItem> dataItems = keyword.getDataItems();
 
         for(int i = 0; i < dataItems.size(); ++i) {
-            DataItem item = (DataItem)dataItems.get(i);
-            Iterator var5 = ProcessorStorage.getStorage().getProcessors().iterator();
-
-            while(var5.hasNext()) {
-                Processor dataItemProcessor = (Processor)var5.next();
+            DataItem item = dataItems.get(i);
+            for (Processor dataItemProcessor : ProcessorStorage.getStorage().getProcessors()) {
                 dataItems.set(i, dataItemProcessor.process(item));
             }
         }
-
     }
 
     protected void throwTCE(Keyword keyword, Throwable e) throws TestCaseException {
@@ -134,14 +128,10 @@ public class KeywordExecutor extends SectionExecutor {
     }
 
     protected static void replaceParametersInKeyword(Keyword keyword) {
-        Iterator var1 = keyword.getDataItems().iterator();
-
-        while(var1.hasNext()) {
-            DataItem item = (DataItem)var1.next();
+        for (DataItem item : keyword.getDataItems()) {
             String value = KDTUtils.replaceParametersInString(keyword, item.getData());
             item.setData(value);
         }
-
     }
 
     protected static void routeNotFound(Keyword keyword) {
@@ -163,7 +153,7 @@ public class KeywordExecutor extends SectionExecutor {
     }
 
     public static Keyword getKeyword() {
-        return (Keyword)currentKeyword.get();
+        return currentKeyword.get();
     }
 
     public static void removeInstance() {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/PooledTestSuiteExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/PooledTestSuiteExecutor.java
@@ -56,7 +56,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
         log.info("[START] test suite execution: " + suite);
 
         try {
-            this.execute((Collection)suite.getChildren());
+            this.execute(suite.getChildren());
         } finally {
             ResourceFactory.getInstance().releaseResourcesAll();
             log.info("[END] test suite execution: " + suite.getName());
@@ -70,19 +70,15 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
             public String apply(@Nullable Executable input) {
                 return input.getName();
             }
-        }).toString());
-        if (testCases.size() == 0) {
+        }));
+        if (testCases.isEmpty()) {
             log.warn("No one test case is specified for execution!");
         } else {
             ExecutorService threadPool = Executors.newFixedThreadPool(threadLimit);
-            List<Runnable> threads = this.prepareThreadList((Iterable)testCases);
-            Iterator var4 = threads.iterator();
-
-            while(var4.hasNext()) {
-                Runnable thread = (Runnable)var4.next();
+            List<Runnable> threads = this.prepareThreadList(testCases);
+            for (Runnable thread : threads) {
                 threadPool.execute(thread);
             }
-
             threadPool.shutdown();
             threadPool.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
         }
@@ -91,12 +87,12 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
     /** @deprecated */
     @Deprecated
     protected List<Runnable> prepareThreadList(Executable executable) {
-        return this.prepareThreadList((Iterable)executable.getChildren());
+        return this.prepareThreadList(executable.getChildren());
     }
 
     protected List<Runnable> prepareThreadList(Iterable<Executable> testCases) {
-        List<Runnable> threads = new ArrayList();
-        Map<String, List<Executable>> threadNameMap = new LinkedHashMap();
+        List<Runnable> threads = new ArrayList<>();
+        Map<String, List<Executable>> threadNameMap = new LinkedHashMap<>();
         Iterator var4 = testCases.iterator();
 
         while(true) {
@@ -107,7 +103,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
                         if (threadNameMap.get(ftc.getThreadName()) != null) {
                             ((List)threadNameMap.get(ftc.getThreadName())).add(ftc);
                         } else {
-                            ArrayList<Executable> list = new ArrayList();
+                            ArrayList<Executable> list = new ArrayList<>();
                             list.add(ftc);
                             threadNameMap.put(ftc.getThreadName(), list);
                         }
@@ -122,7 +118,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
 
             while(var4.hasNext()) {
                 List<Executable> list = (List)var4.next();
-                threads.add(new ExecutableRunnable((Executable[])list.toArray(new Executable[0])));
+                threads.add(new ExecutableRunnable(list.toArray(new Executable[0])));
             }
 
             return threads;
@@ -138,7 +134,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
     }
 
     public static class ExecutableRunnable implements Runnable {
-        private Executable[] executables;
+        private final Executable[] executables;
 
         public ExecutableRunnable(Executable... executables) {
             this.executables = executables;
@@ -149,23 +145,16 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
         }
 
         public void run() {
-            Executable[] var1 = this.executables;
-            int var2 = var1.length;
-
-            for(int var3 = 0; var3 < var2; ++var3) {
-                Executable executable = var1[var3];
-
+            for (Executable executable : this.executables) {
                 try {
                     ReportUtils.setReportFolderName(executable.getName());
                     executable.execute();
-                } catch (Throwable var9) {
-                    Throwable e = var9;
+                } catch (Throwable e) {
                     PooledTestSuiteExecutor.handleException(executable, e);
                 } finally {
                     this.releaseResources();
                 }
             }
-
             Resources.releaseResourcesForCurrentThreadSilently();
         }
 
@@ -176,11 +165,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
 
             Throwable e;
             try {
-                Executable[] var7 = this.executables;
-                int var2 = var7.length;
-
-                for(int var3 = 0; var3 < var2; ++var3) {
-                    Executable executable = var7[var3];
+                for (Executable executable : this.executables) {
                     if (executable.getParent() != null) {
                         executable.getParent().getChildren().remove(executable);
                     }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/PooledTestSuiteExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/PooledTestSuiteExecutor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,18 +16,6 @@
 
 package org.qubership.atp.adapter.keyworddriven.executor;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-import org.qubership.atp.adapter.keyworddriven.configuration.KdtProperties;
-import org.qubership.atp.adapter.keyworddriven.executable.Executable;
-import org.qubership.atp.adapter.keyworddriven.executable.FileTestCase;
-import org.qubership.atp.adapter.keyworddriven.resources.ResourceFactory;
-import org.qubership.atp.adapter.keyworddriven.resources.Resources;
-import org.qubership.atp.adapter.report.Report;
-import org.qubership.atp.adapter.testcase.Config;
-import org.qubership.atp.adapter.utils.ExceptionUtils;
-import org.qubership.atp.adapter.utils.ReportUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -37,10 +25,24 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.qubership.atp.adapter.keyworddriven.configuration.KdtProperties;
+import org.qubership.atp.adapter.keyworddriven.executable.Executable;
+import org.qubership.atp.adapter.keyworddriven.executable.FileTestCase;
+import org.qubership.atp.adapter.keyworddriven.resources.ResourceFactory;
+import org.qubership.atp.adapter.keyworddriven.resources.Resources;
+import org.qubership.atp.adapter.report.Report;
+import org.qubership.atp.adapter.testcase.Config;
+import org.qubership.atp.adapter.utils.ExceptionUtils;
+import org.qubership.atp.adapter.utils.ReportUtils;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import jakarta.annotation.Nullable;
 
 public class PooledTestSuiteExecutor extends SectionExecutor {
     private static final Logger log = Logger.getLogger(PooledTestSuiteExecutor.class);
@@ -100,8 +102,7 @@ public class PooledTestSuiteExecutor extends SectionExecutor {
         while(true) {
             while(var4.hasNext()) {
                 Executable child = (Executable)var4.next();
-                if (child instanceof FileTestCase) {
-                    FileTestCase ftc = (FileTestCase)child;
+                if (child instanceof FileTestCase ftc) {
                     if (StringUtils.isNotBlank(ftc.getThreadName())) {
                         if (threadNameMap.get(ftc.getThreadName()) != null) {
                             ((List)threadNameMap.get(ftc.getThreadName())).add(ftc);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/SectionExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/SectionExecutor.java
@@ -33,7 +33,7 @@ import org.qubership.atp.adapter.utils.KDTUtils;
 
 public class SectionExecutor implements Executor {
     private static final Log log = LogFactory.getLog(SectionExecutor.class);
-    private List<ExecuteListener> executeListeners = new ArrayList();
+    private final List<ExecuteListener> executeListeners = new ArrayList<>();
 
     public SectionExecutor() {
     }
@@ -54,13 +54,9 @@ public class SectionExecutor implements Executor {
     }
 
     public void prepare(Executable executable) {
-        Iterator var2 = executable.getChildren().iterator();
-
-        while(var2.hasNext()) {
-            Executable child = (Executable)var2.next();
+        for (Executable child : executable.getChildren()) {
             child.prepare();
         }
-
     }
 
     public void addExecuteListener(ExecuteListener listener) {
@@ -72,23 +68,15 @@ public class SectionExecutor implements Executor {
     }
 
     public void executeBefore(Executable executable) {
-        Iterator var2 = this.executeListeners.iterator();
-
-        while(var2.hasNext()) {
-            ExecuteListener listener = (ExecuteListener)var2.next();
+        for (ExecuteListener listener : this.executeListeners) {
             listener.beforeExecute(executable);
         }
-
     }
 
     public void executeAfter(Executable executable) {
-        Iterator var2 = this.executeListeners.iterator();
-
-        while(var2.hasNext()) {
-            ExecuteListener listener = (ExecuteListener)var2.next();
+        for (ExecuteListener listener : this.executeListeners) {
             listener.afterExecute(executable);
         }
-
     }
 
     private boolean skip(Executable executable) {
@@ -102,30 +90,25 @@ public class SectionExecutor implements Executor {
     }
 
     protected void executeChildren(Section section) throws Exception {
-        Iterator<Executable> childen = section.getChildren().iterator();
+        Iterator<Executable> children = section.getChildren().iterator();
         Executable current = null;
-
         try {
-            while(childen.hasNext()) {
-                current = (Executable)childen.next();
+            while(children.hasNext()) {
+                current = children.next();
                 current.execute();
             }
-        } catch (Exception var9) {
-            Exception e = var9;
+        } catch (Exception e) {
             if (!ExceptionUtils.isHandled(e)) {
                 TestCaseException handledException = ExceptionUtils.handle(e, "Error occurred during execution section: " + current + ".\n Error: " + e.getMessage());
                 Report.getReport().message(handledException);
                 throw handledException;
             }
-
             throw e;
         } finally {
-            while(childen.hasNext()) {
-                Report.getReport().message(new BlockedExecutable((Executable)childen.next()));
+            while(children.hasNext()) {
+                Report.getReport().message(new BlockedExecutable(children.next()));
             }
-
         }
-
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/SectionExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/executor/SectionExecutor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,12 @@
 
 package org.qubership.atp.adapter.keyworddriven.executor;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.qubership.atp.adapter.keyworddriven.TestCaseException;
 import org.qubership.atp.adapter.keyworddriven.executable.BlockedExecutable;
 import org.qubership.atp.adapter.keyworddriven.executable.Executable;
@@ -24,11 +30,6 @@ import org.qubership.atp.adapter.report.Report;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.ExceptionUtils;
 import org.qubership.atp.adapter.utils.KDTUtils;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 public class SectionExecutor implements Executor {
     private static final Log log = LogFactory.getLog(SectionExecutor.class);
@@ -64,7 +65,7 @@ public class SectionExecutor implements Executor {
 
     public void addExecuteListener(ExecuteListener listener) {
         if (Config.getBoolean("kdt.check.listeners.are.already.registered", true) && this.executeListeners.contains(listener)) {
-            log.warn(String.format("Try to register already registered '%s' to '%s'", listener, this));
+            log.warn("Try to register already registered '%s' to '%s'".formatted(listener, this));
         } else {
             this.executeListeners.add(listener);
         }
@@ -93,7 +94,7 @@ public class SectionExecutor implements Executor {
     private boolean skip(Executable executable) {
         Section section = (Section)executable;
         if (section.getValidationLevel() > KeywordExecutor.validationLevel) {
-            section.log().debug(String.format("Section '%s' was skipped because validation level of it is bigger than execution level ( %s > %s )", section.getFullName(), section.getValidationLevel(), KeywordExecutor.validationLevel));
+            section.log().debug("Section '%s' was skipped because validation level of it is bigger than execution level ( %s > %s )".formatted(section.getFullName(), section.getValidationLevel(), KeywordExecutor.validationLevel));
             return true;
         } else {
             return false;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/handlers/ActionMethodExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/handlers/ActionMethodExecutor.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.qubership.atp.adapter.keyworddriven.ActionExecutionException;
 import org.qubership.atp.adapter.keyworddriven.ActionsFactory;
 import org.qubership.atp.adapter.keyworddriven.ParametersHandlerException;
 import org.qubership.atp.adapter.keyworddriven.databinder.Calculators;
@@ -73,7 +72,7 @@ public abstract class ActionMethodExecutor implements ActionExecutor {
         return sb.toString();
     }
 
-    protected abstract void execute(Object var1, Method var2, Object[] var3) throws ActionExecutionException, Exception;
+    protected abstract void execute(Object var1, Method var2, Object[] var3) throws Exception;
 
     protected Object[] getActionArguments(Keyword keyword) throws ParametersHandlerException {
         LinkedHashMap<String, KeywordParameter> keywordParameters = keyword.getKeywordParameters();
@@ -83,15 +82,15 @@ public abstract class ActionMethodExecutor implements ActionExecutor {
 
         for(int i = 0; i < signature.length; ++i) {
             Type paramType = signature[i];
-            if (Calculators.getCalculator((Type)paramType) == null) {
+            if (Calculators.getCalculator(paramType) == null) {
                 paramType = this.method.getParameterTypes()[i];
             }
 
             Object param;
-            if (this.defaultValues != null && this.defaultValues.size() != 0) {
-                param = getParam(keywordParameters, this.defaultValues, (Type)paramType, numberParam);
+            if (this.defaultValues != null && !this.defaultValues.isEmpty()) {
+                param = getParam(keywordParameters, this.defaultValues, paramType, numberParam);
             } else {
-                param = getParam(keywordParameters, (Type)paramType, numberParam);
+                param = getParam(keywordParameters, paramType, numberParam);
             }
 
             arglist[numberParam] = param;
@@ -102,9 +101,9 @@ public abstract class ActionMethodExecutor implements ActionExecutor {
     }
 
     protected static Object getParam(LinkedHashMap<String, KeywordParameter> routeParameters, Collection<RouteItem> defaultValues, Type paramType, int numberParam) throws ParametersHandlerException {
-        RouteItem item = ((RouteItem[])defaultValues.toArray(new RouteItem[defaultValues.size()]))[numberParam];
+        RouteItem item = ((RouteItem[])defaultValues.toArray(new RouteItem[0]))[numberParam];
         if (item.isParameter()) {
-            KeywordParameter par = (KeywordParameter)routeParameters.get(item.getParamName());
+            KeywordParameter par = routeParameters.get(item.getParamName());
             return getCalc(paramType).calculate(par);
         } else {
             return item.getSource();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/handlers/ActionMethodExecutor.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/handlers/ActionMethodExecutor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,15 @@
 
 package org.qubership.atp.adapter.keyworddriven.handlers;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.qubership.atp.adapter.keyworddriven.ActionExecutionException;
 import org.qubership.atp.adapter.keyworddriven.ActionsFactory;
 import org.qubership.atp.adapter.keyworddriven.ParametersHandlerException;
@@ -26,15 +33,10 @@ import org.qubership.atp.adapter.keyworddriven.databinder.DataBinder;
 import org.qubership.atp.adapter.keyworddriven.executable.Keyword;
 import org.qubership.atp.adapter.keyworddriven.executable.KeywordParameter;
 import org.qubership.atp.adapter.keyworddriven.routing.RouteItem;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import jakarta.annotation.Nullable;
 
 public abstract class ActionMethodExecutor implements ActionExecutor {
     private static final Logger log = Logger.getLogger(ActionMethodExecutor.class);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/KeywordRouteTable.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/KeywordRouteTable.java
@@ -24,8 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.qubership.atp.adapter.keyworddriven.configuration.DefaultConfiguration;
@@ -42,6 +40,7 @@ import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 
 import com.google.inject.Inject;
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/KeywordRouteTable.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/KeywordRouteTable.java
@@ -111,7 +111,7 @@ public class KeywordRouteTable {
                 log.error("No one route is found for keyword '{}'", keyword);
                 return null;
             } else if (result.size() == 1) {
-                return result.get(0);
+                return result.getFirst();
             } else {
                 log.error("More than one route is found for keyword '{}'. Matched routes: {}", keyword, result);
                 return null;
@@ -121,52 +121,34 @@ public class KeywordRouteTable {
 
     public static void calculateRoutesRating() {
         log.info("Routes calculation started");
-        Iterator var0 = routeGroups.values().iterator();
-
-        while(var0.hasNext()) {
-            List<Route> routeGroup = (List)var0.next();
-            Iterator var2 = routeGroup.iterator();
-
-            while(var2.hasNext()) {
-                Route route = (Route)var2.next();
+        for (RouteGroup routes : routeGroups.values()) {
+            List<Route> routeGroup = (List) routes;
+            for (Route route : routeGroup) {
                 int rating = 0;
-                Iterator var5 = routeGroups.values().iterator();
-
-                while(var5.hasNext()) {
-                    List<Route> routeGroup2 = (List)var5.next();
-                    Iterator var7 = routeGroup2.iterator();
-
-                    while(var7.hasNext()) {
-                        Route route2 = (Route)var7.next();
+                for (RouteGroup group : routeGroups.values()) {
+                    List<Route> routeGroup2 = (List) group;
+                    for (Route route2 : routeGroup2) {
                         if (route != route2 && route.isSubsetOf(route2)) {
                             ++rating;
                         }
                     }
                 }
-
                 route.setRating(rating);
             }
         }
-
         log.info("Routes calculation completed");
     }
 
     public static ArrayList<Route> getRoutesByName(String name) {
         ArrayList<Route> list = new ArrayList<>();
-        Iterator var2 = routeGroups.values().iterator();
-
-        while(var2.hasNext()) {
-            List<Route> routeGroup = (List)var2.next();
-            Iterator var4 = routeGroup.iterator();
-
-            while(var4.hasNext()) {
-                Route route = (Route)var4.next();
+        for (RouteGroup routes : routeGroups.values()) {
+            List<Route> routeGroup = (List) routes;
+            for (Route route : routeGroup) {
                 if (route.getName().equalsIgnoreCase(name)) {
                     list.add(route);
                 }
             }
         }
-
         return list;
     }
 
@@ -174,22 +156,17 @@ public class KeywordRouteTable {
         if (mapper == null) {
             KDTUtils.criticalMessAndExit("KeywordMapper is not specified. Default implementation is activated by adding parameter 'library.actions.*' with value = '" + DefaultConfiguration.class + "'");
         }
-
         mapper.assignData(keyword, route);
         checkAssignRouteAndExit(keyword);
     }
 
     private static void checkAssignRouteAndExit(Keyword keyword) {
         Route route = keyword.getRoute();
-        Iterator var2 = keyword.getDataItems().iterator();
-
-        while(var2.hasNext()) {
-            DataItem dataItem = (DataItem)var2.next();
+        for (DataItem dataItem : keyword.getDataItems()) {
             if (dataItem.getRouteItem() == null) {
                 KDTUtils.criticalMessAndExit("Fatal error in assigning route to keyword.\nRoute: " + route.toString() + "\nRoute Mask: " + route.getRouteMask() + "\nKeyword: " + keyword + "\nKeyword Compare String: " + keyword.getStringToCompare());
             }
         }
-
     }
 
     public static boolean matches(Keyword keyword, Route route) {
@@ -217,12 +194,11 @@ public class KeywordRouteTable {
         if (groupName == null || groupName.isEmpty()) {
             groupName = "Other";
         }
-
         if (!routeGroups.containsKey(groupName)) {
             routeGroups.put(groupName, new RouteGroup(groupName));
         }
 
-        return (List)routeGroups.get(groupName);
+        return routeGroups.get(groupName);
     }
 
     public static LinkedHashMap<String, RouteGroup> getRouteGroups() {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/MethodKeywordRoute.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/MethodKeywordRoute.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package org.qubership.atp.adapter.keyworddriven.routing;
 
-import org.qubership.atp.adapter.keyworddriven.databinder.Calculators;
-import org.qubership.atp.adapter.keyworddriven.handlers.ActionMethodExecutor;
-import org.qubership.atp.adapter.keyworddriven.handlers.DefaultActionExecutor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.qubership.atp.adapter.keyworddriven.databinder.Calculators;
+import org.qubership.atp.adapter.keyworddriven.handlers.ActionMethodExecutor;
+import org.qubership.atp.adapter.keyworddriven.handlers.DefaultActionExecutor;
 
 public class MethodKeywordRoute extends Route {
     private static final Log log = LogFactory.getLog(MethodKeywordRoute.class);
@@ -72,9 +73,9 @@ public class MethodKeywordRoute extends Route {
             ((ActionMethodExecutor)this.getExecutor()).setDefaultValues(defaultValuesParsed);
             this.checkCalcs(method, defaultValuesParsed);
         } catch (SecurityException var11) {
-            throw new IllegalArgumentException(String.format("There is no access to method '%s.%s(%s)'. Route: %s", actionClass.getCanonicalName(), methodName, toString(signature), this.toString()));
+            throw new IllegalArgumentException("There is no access to method '%s.%s(%s)'. Route: %s".formatted(actionClass.getCanonicalName(), methodName, toString(signature), this.toString()));
         } catch (NoSuchMethodException var12) {
-            throw new IllegalArgumentException(String.format("Method '%s.%s(%s)' does not exist. Route: %s", actionClass.getCanonicalName(), methodName, toString(signature), this.toString()));
+            throw new IllegalArgumentException("Method '%s.%s(%s)' does not exist. Route: %s".formatted(actionClass.getCanonicalName(), methodName, toString(signature), this.toString()));
         }
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/MethodKeywordRoute.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/MethodKeywordRoute.java
@@ -16,7 +16,6 @@
 
 package org.qubership.atp.adapter.keyworddriven.routing;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -32,35 +31,35 @@ public class MethodKeywordRoute extends Route {
     private static final Log log = LogFactory.getLog(MethodKeywordRoute.class);
 
     public MethodKeywordRoute(String[] keywordMask, Class<?> actionClass, String methodName, Class<?>... signature) {
-        this((String)null, keywordMask, (Class)null, actionClass, methodName, signature, (Object[])null);
+        this(null, keywordMask, null, actionClass, methodName, signature, null);
     }
 
     public MethodKeywordRoute(String description, String[] keywordMask, Class<?> actionClass, String methodName, Class<?>... signature) {
-        this(description, keywordMask, (Class)null, actionClass, methodName, signature, (Object[])null);
+        this(description, keywordMask, null, actionClass, methodName, signature, null);
     }
 
     public MethodKeywordRoute(String[] keywordMask, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
-        this((String)null, keywordMask, (Class)null, actionClass, methodName, signature, defaultValues);
+        this((String)null, keywordMask, null, actionClass, methodName, signature, defaultValues);
     }
 
     public MethodKeywordRoute(String description, String[] keywordMask, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
-        this(description, keywordMask, (Class)null, actionClass, methodName, signature, defaultValues);
+        this(description, keywordMask, null, actionClass, methodName, signature, defaultValues);
     }
 
     public MethodKeywordRoute(boolean isDeprecated, String description, String[] keywordMask, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
-        this(isDeprecated, description, keywordMask, (Class)null, actionClass, methodName, signature, defaultValues);
+        this(isDeprecated, description, keywordMask, null, actionClass, methodName, signature, defaultValues);
     }
 
     public MethodKeywordRoute(String[] keywordMask, Class<? extends ActionMethodExecutor> handler, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
-        this((String)null, keywordMask, handler, actionClass, methodName, signature, defaultValues);
+        this(null, keywordMask, handler, actionClass, methodName, signature, defaultValues);
     }
 
     public MethodKeywordRoute(String[] keywordMask, Class<? extends ActionMethodExecutor> handler, Class<?> actionClass, String methodName, Class<?>[] signature) {
-        this((String)null, keywordMask, handler, actionClass, methodName, signature, (Object[])null);
+        this(null, keywordMask, handler, actionClass, methodName, signature, null);
     }
 
     public MethodKeywordRoute(String description, String[] keywordMask, Class<? extends ActionMethodExecutor> handler, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
-        this(false, (String)null, keywordMask, handler, actionClass, methodName, signature, (Object[])null);
+        this(false, null, keywordMask, handler, actionClass, methodName, signature, null);
     }
 
     public MethodKeywordRoute(boolean deprecated, String description, String[] keywordMask, Class<? extends ActionMethodExecutor> handler, Class<?> actionClass, String methodName, Class<?>[] signature, Object[] defaultValues) {
@@ -92,8 +91,8 @@ public class MethodKeywordRoute extends Route {
         }
     }
 
-    protected static ActionMethodExecutor getExecutor(Class<? extends ActionMethodExecutor> clazz, Method method, Collection<RouteItem> defaultValues) throws IllegalArgumentException, SecurityException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        ActionMethodExecutor res = (ActionMethodExecutor)clazz.newInstance();
+    protected static ActionMethodExecutor getExecutor(Class<? extends ActionMethodExecutor> clazz, Method method, Collection<RouteItem> defaultValues) throws IllegalArgumentException, SecurityException, InstantiationException, IllegalAccessException {
+        ActionMethodExecutor res = clazz.newInstance();
         res.setMethod(method);
         res.setDefaultValues(defaultValues);
         return res;
@@ -118,18 +117,14 @@ public class MethodKeywordRoute extends Route {
 
     private static String toString(Class<?>... classes) {
         StringBuilder sb = new StringBuilder();
-        Class[] var2 = classes;
-        int var3 = classes.length;
-
-        for(int var4 = 0; var4 < var3; ++var4) {
-            Class clazz = var2[var4];
+        for(int var4 = 0; var4 < classes.length; ++var4) {
+            Class clazz = ((Class[]) classes)[var4];
             sb.append(clazz.getCanonicalName()).append(", ");
         }
 
-        if (sb.length() > 0) {
+        if (!sb.isEmpty()) {
             sb.delete(sb.length() - 2, sb.length());
         }
-
         return sb.toString();
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/PatternConverter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/PatternConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.qubership.atp.adapter.keyworddriven.routing;
 
 import java.util.regex.Pattern;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -42,7 +43,7 @@ public class PatternConverter {
 
         sb.append(str.substring(indexE + 2));
         automaton = sb.toString();
-        log.trace(String.format("Convert route java regexp to automaton regexp '%s' > '%s'", str, automaton));
+        log.trace("Convert route java regexp to automaton regexp '%s' > '%s'".formatted(str, automaton));
         return automaton;
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 
 package org.qubership.atp.adapter.keyworddriven.routing;
 
-import org.qubership.atp.adapter.keyworddriven.handlers.ActionExecutor;
-import org.qubership.atp.adapter.testcase.Config;
-import dk.brics.automaton.Automaton;
-import dk.brics.automaton.RegExp;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.qubership.atp.adapter.keyworddriven.handlers.ActionExecutor;
+import org.qubership.atp.adapter.testcase.Config;
+
+import dk.brics.automaton.Automaton;
+import dk.brics.automaton.RegExp;
 
 public abstract class Route {
     private static final Log log = LogFactory.getLog(Route.class);
@@ -59,14 +61,14 @@ public abstract class Route {
             this.routeMask = this.getRouteMask(routeItems);
         } catch (PatternSyntaxException var7) {
             PatternSyntaxException e = var7;
-            throw new IllegalArgumentException(String.format("Route '%s' has wrong format of '%s'. Error: %s", description, routeItems.toString(), e.getMessage()), e);
+            throw new IllegalArgumentException("Route '%s' has wrong format of '%s'. Error: %s".formatted(description, routeItems.toString(), e.getMessage()), e);
         }
 
         try {
             this.maskAutomaton = (new RegExp(PatternConverter.convert(this.routeMask))).toAutomaton(true);
         } catch (IllegalArgumentException var6) {
             IllegalArgumentException e = var6;
-            throw new IllegalArgumentException(String.format("Route '%s' has wrong format of pattern '%s'. Error: %s", routeItems.toString(), this.routeMask.pattern(), e.getMessage()), e);
+            throw new IllegalArgumentException("Route '%s' has wrong format of pattern '%s'. Error: %s".formatted(routeItems.toString(), this.routeMask.pattern(), e.getMessage()), e);
         }
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
@@ -150,7 +150,7 @@ public abstract class Route {
 
     protected static ActionExecutor getExecutor(Class<? extends ActionExecutor> clazz) {
         try {
-            return (ActionExecutor)clazz.newInstance();
+            return (ActionExecutor)clazz.getDeclaredConstructor().newInstance();
         } catch (Throwable e) {
             log.error("Error route instantiation:" + e);
             return null;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/Route.java
@@ -34,19 +34,19 @@ public abstract class Route {
     public static final boolean IS_SPACE_DELIM_ENABLED = Boolean.parseBoolean(Config.getString("kdt.enable.llk"));
     private final ArrayList<RouteItem> routeItems;
     private final ActionExecutor executor;
-    private Pattern routeMask;
-    private Automaton maskAutomaton;
+    private final Pattern routeMask;
+    private final Automaton maskAutomaton;
     private int rating;
     private final String description;
-    private String delim;
+    private final String delim;
     private final boolean deprecated;
 
     public Route(ArrayList<RouteItem> routeItems, Class<? extends ActionExecutor> executor) {
-        this((String)null, routeItems, executor);
+        this(null, routeItems, executor);
     }
 
     public Route(String description, ArrayList<RouteItem> routeItems, Class<? extends ActionExecutor> executor) {
-        this((String)null, routeItems, executor, false);
+        this(null, routeItems, executor, false);
     }
 
     public Route(String description, ArrayList<RouteItem> routeItems, Class<? extends ActionExecutor> executor, boolean deprecated) {
@@ -59,15 +59,13 @@ public abstract class Route {
 
         try {
             this.routeMask = this.getRouteMask(routeItems);
-        } catch (PatternSyntaxException var7) {
-            PatternSyntaxException e = var7;
+        } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException("Route '%s' has wrong format of '%s'. Error: %s".formatted(description, routeItems.toString(), e.getMessage()), e);
         }
 
         try {
             this.maskAutomaton = (new RegExp(PatternConverter.convert(this.routeMask))).toAutomaton(true);
-        } catch (IllegalArgumentException var6) {
-            IllegalArgumentException e = var6;
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Route '%s' has wrong format of pattern '%s'. Error: %s".formatted(routeItems.toString(), this.routeMask.pattern(), e.getMessage()), e);
         }
     }
@@ -77,7 +75,7 @@ public abstract class Route {
     }
 
     public String getName() {
-        return ((RouteItem)this.routeItems.get(0)).toString();
+        return this.routeItems.getFirst().toString();
     }
 
     public Pattern getRouteMask() {
@@ -89,7 +87,7 @@ public abstract class Route {
         String tab = "";
 
         for(int index = 0; index < routeItems.size(); ++index) {
-            RouteItem item = (RouteItem)routeItems.get(index);
+            RouteItem item = routeItems.get(index);
             if (index > 0) {
                 tab = this.delim;
             }
@@ -139,13 +137,9 @@ public abstract class Route {
     }
 
     public static ArrayList<RouteItem> parseMaskInRouteItems(Object[] sourceMask) {
-        ArrayList<RouteItem> res = new ArrayList();
-        Object[] var2 = sourceMask;
-        int var3 = sourceMask.length;
-
-        for(int var4 = 0; var4 < var3; ++var4) {
-            Object itemSource = var2[var4];
-            if (!(itemSource instanceof String) || !((String)itemSource).isEmpty()) {
+        ArrayList<RouteItem> res = new ArrayList<>();
+        for (Object itemSource : sourceMask) {
+            if (!(itemSource instanceof String) || !((String) itemSource).isEmpty()) {
                 RouteItem routeItem = new RouteItem(itemSource);
                 res.add(routeItem);
             }
@@ -157,8 +151,7 @@ public abstract class Route {
     protected static ActionExecutor getExecutor(Class<? extends ActionExecutor> clazz) {
         try {
             return (ActionExecutor)clazz.newInstance();
-        } catch (Throwable var2) {
-            Throwable e = var2;
+        } catch (Throwable e) {
             log.error("Error route instantiation:" + e);
             return null;
         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteGroup.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,15 +16,18 @@
 
 package org.qubership.atp.adapter.keyworddriven.routing;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.LinkedList;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class RouteGroup extends LinkedList<Route> {
     private static final Log log = LogFactory.getLog(RouteGroup.class);
     private final String name;
-    private static final long serialVersionUID = -5456796519418419700L;
+  @Serial
+  private static final long serialVersionUID = -5456796519418419700L;
 
     public RouteGroup(String name) {
         this.name = name;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteGroup.java
@@ -26,8 +26,8 @@ import org.apache.commons.logging.LogFactory;
 public class RouteGroup extends LinkedList<Route> {
     private static final Log log = LogFactory.getLog(RouteGroup.class);
     private final String name;
-  @Serial
-  private static final long serialVersionUID = -5456796519418419700L;
+    @Serial
+    private static final long serialVersionUID = -5456796519418419700L;
 
     public RouteGroup(String name) {
         this.name = name;
@@ -49,12 +49,12 @@ public class RouteGroup extends LinkedList<Route> {
     }
 
     public boolean addAll(Collection<? extends Route> c) {
-        this.logRouteAdding((Route[])c.toArray(new Route[c.size()]));
+        this.logRouteAdding(c.toArray(new Route[0]));
         return super.addAll(c);
     }
 
     public boolean addAll(int index, Collection<? extends Route> c) {
-        this.logRouteAdding((Route[])c.toArray(new Route[c.size()]));
+        this.logRouteAdding(c.toArray(new Route[0]));
         return super.addAll(index, c);
     }
 
@@ -65,19 +65,13 @@ public class RouteGroup extends LinkedList<Route> {
 
     protected void logRouteAdding(Route... c) {
         if (log.isTraceEnabled()) {
-            Route[] var2 = c;
-            int var3 = c.length;
-
-            for(int var4 = 0; var4 < var3; ++var4) {
-                Route e = var2[var4];
+            for (Route e : c) {
                 log.trace("Route added into " + this.getName() + " group:" + e);
             }
         }
-
     }
 
     public String getName() {
         return this.name;
     }
 }
-

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteItem.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/keyworddriven/routing/RouteItem.java
@@ -36,8 +36,8 @@ public class RouteItem {
 
     public RouteItem(Object source) {
         this.source = source;
-        if (source instanceof String) {
-            this.parseMaskItem((String)source);
+        if (source instanceof String string) {
+            this.parseMaskItem(string);
         }
 
     }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/AbstractWebReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/AbstractWebReportWriter.java
@@ -16,7 +16,6 @@
 
 package org.qubership.atp.adapter.report;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -80,7 +79,7 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
                                     break label119;
                                 }
 
-                                entry = (JarEntry)e.nextElement();
+                                entry = e.nextElement();
                                 entryName = entry.getName();
                             } while(!entryName.startsWith(s));
                         } while(entryName.equals(s));
@@ -105,10 +104,10 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
 
                                 int read;
                                 while((read = is.read(buffer)) != -1) {
-                                    ((OutputStream)os).write(buffer, 0, read);
+                                    os.write(buffer, 0, read);
                                 }
                             } finally {
-                                Utils.close(new Closeable[]{is, os});
+                                Utils.close(is, os);
                             }
                         }
                     }
@@ -116,16 +115,10 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
             } else {
                 FileUtils.copyDirectory(new File(connection.getURL().toURI()), reportDir);
             }
-        } catch (IOException var21) {
-            IOException e = var21;
-            LOG.error("Unable to find report files", e);
-            return;
-        } catch (URISyntaxException var22) {
-            URISyntaxException e = var22;
+        } catch (IOException | URISyntaxException e) {
             LOG.error("Unable to find report files", e);
             return;
         }
-
         this.prepareIndexFile();
     }
 
@@ -133,7 +126,7 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
 
     protected String getReportDirRoot(Properties p) {
         String reportRootDir = p == null ? Config.getString("report.dir.root") : p.getProperty("report.dir.root", Config.getString("report.dir.root"));
-        if (reportRootDir.length() == 0) {
+        if (reportRootDir.isEmpty()) {
             reportRootDir = "results";
         }
 
@@ -142,7 +135,7 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
 
     protected String getReportDirName(Properties p) {
         String suffix = p == null ? "" : p.getProperty("suffix", "");
-        if (suffix.length() > 0) {
+        if (!suffix.isEmpty()) {
             suffix = "_" + suffix;
         }
 
@@ -161,12 +154,8 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
             Class<Charset> c = Charset.class;
             Field defaultCharsetField = c.getDeclaredField("defaultCharset");
             defaultCharsetField.setAccessible(true);
-            defaultCharsetField.set((Object)null, Charset.forName(encoding));
-        } catch (NoSuchFieldException var3) {
-            NoSuchFieldException ex = var3;
-            LOG.warn("Can't set encoding", ex);
-        } catch (IllegalAccessException var4) {
-            IllegalAccessException ex = var4;
+            defaultCharsetField.set(null, Charset.forName(encoding));
+        } catch (NoSuchFieldException | IllegalAccessException ex) {
             LOG.warn("Can't set encoding", ex);
         }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/AbstractWebReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/AbstractWebReportWriter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.qubership.atp.adapter.report;
 
-import org.qubership.atp.adapter.testcase.Config;
-import org.qubership.atp.adapter.utils.Utils;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,9 +33,12 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.qubership.atp.adapter.testcase.Config;
+import org.qubership.atp.adapter.utils.Utils;
 
 public abstract class AbstractWebReportWriter implements ReportWriter {
     private static final Log LOG = LogFactory.getLog(AbstractWebReportWriter.class);
@@ -64,8 +65,8 @@ public abstract class AbstractWebReportWriter implements ReportWriter {
         try {
             String s = this.getResourcesLocationInJar();
             URLConnection connection = this.getClass().getClassLoader().getResource(s).openConnection();
-            if (connection instanceof JarURLConnection) {
-                JarFile archive = ((JarURLConnection)connection).getJarFile();
+            if (connection instanceof JarURLConnection lConnection) {
+                JarFile archive = lConnection.getJarFile();
                 Enumeration<? extends JarEntry> e = archive.entries();
 
                 label119:

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/GeneralReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/GeneralReportWriter.java
@@ -255,7 +255,7 @@ public class GeneralReportWriter implements ReportWriter {
         StringBuilder headerPart = new StringBuilder();
         long execTime = (System.currentTimeMillis() - this.startTime) / 1000L;
         headerPart.append("<b>Report Time: </b>").append("date=\"").append(dateFormat.format(new Date())).append("\" t=\"").append(timeFormat.format(new Date())).append("\"").append("<br/>");
-        headerPart.append("<b>Duration: </b>").append(String.format("%02d hours %02d minutes", execTime / 3600L, execTime % 3600L / 60L)).append("<br/>");
+        headerPart.append("<b>Duration: </b>").append("%02d hours %02d minutes".formatted(execTime / 3600L, execTime % 3600L / 60L)).append("<br/>");
         if (Integer.parseInt(getEnvValue(Config.getString(SERVER_ALIAS_KEY) + ".threads", "1")) > 1) {
             headerPart.append("<b>Threads: </b>").append(getEnvValue(Config.getString(SERVER_ALIAS_KEY) + ".threads", "1")).append("<br/>");
         }
@@ -305,9 +305,9 @@ public class GeneralReportWriter implements ReportWriter {
         for(Iterator i$ = this.scenariosOrdered.iterator(); i$.hasNext(); sb.append("</testcase>")) {
             ScenarioInfo si = (ScenarioInfo)i$.next();
             ++testCount;
-            sb.append(String.format("<testcase classname=\"%s\" name=\"%s\">",
-                    StringEscapeUtils.escapeXml("Test Scope"),
-                    StringEscapeUtils.escapeXml(si.name)));
+            sb.append("<testcase classname=\"%s\" name=\"%s\">".formatted(
+                StringEscapeUtils.escapeXml("Test Scope"),
+                StringEscapeUtils.escapeXml(si.name)));
             if (si.level == 40000) {
                 if ("true".equals(Config.getString("report.junit.ci.url"))) {
                     sb.append("<failure type=\"\"  message=\"" + Config.getString("report.detailed.path")
@@ -449,7 +449,7 @@ public class GeneralReportWriter implements ReportWriter {
 
         public String getExecutionTime() {
             long s = (this.end - this.start) / 1000L;
-            return String.format("%02d:%02d:%02d", s / 3600L, s % 3600L / 60L, s % 60L);
+            return "%02d:%02d:%02d".formatted(s / 3600L, s % 3600L / 60L, s % 60L);
         }
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/GeneralReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/GeneralReportWriter.java
@@ -140,7 +140,7 @@ public class GeneralReportWriter implements ReportWriter {
         StringBuilder returnBuild = new StringBuilder();
 
         while(true) {
-            int ch = ((Reader)reader).read();
+            int ch = reader.read();
             if (ch == -1) {
                 return returnBuild.toString();
             }
@@ -180,8 +180,8 @@ public class GeneralReportWriter implements ReportWriter {
     public synchronized void report(WebReportItem.Message message, Thread thread) {
         synchronized(this.scenarios) {
             if (!this.scenarios.isEmpty()) {
-                List<ScenarioInfo> scenarioList = (List)this.scenarios.get(thread);
-                scenarioList.get(scenarioList.size() - 1).setLevel(message.getLevel().toInt());
+                List<ScenarioInfo> scenarioList = this.scenarios.get(thread);
+                scenarioList.getLast().setLevel(message.getLevel().toInt());
                 Throwable throwable = message.getThrowable();
                 String cause;
                 if (throwable == null) {
@@ -194,8 +194,8 @@ public class GeneralReportWriter implements ReportWriter {
                     cause = "<pre>" + Utils.getStackTrace(throwable) + "</pre>";
                 }
 
-                scenarioList.get(scenarioList.size() - 1).setCause(cause);
-                scenarioList.get(scenarioList.size() - 1).setEndTime(System.currentTimeMillis());
+                scenarioList.getLast().setCause(cause);
+                scenarioList.getLast().setEndTime(System.currentTimeMillis());
             } else {
                 this.newScenario(new WebReportItem.OpenLog(message.getTitle(), message.getMessage()), thread);
                 this.report(message, thread);
@@ -206,16 +206,16 @@ public class GeneralReportWriter implements ReportWriter {
 
     public synchronized void newScenario(WebReportItem.OpenLog message, Thread thread) {
         synchronized(this.scenarios) {
-            List<ScenarioInfo> scenarioList = (List)this.scenarios.get(thread);
+            List<ScenarioInfo> scenarioList = this.scenarios.get(thread);
             if (scenarioList == null) {
-                scenarioList = new ArrayList();
+                scenarioList = new ArrayList<>();
                 this.scenarios.put(thread, scenarioList);
             } else {
                 ((ScenarioInfo)((List)scenarioList).get(scenarioList.size() - 1)).setEndTime(System.currentTimeMillis());
             }
 
             ScenarioInfo soinfo = new ScenarioInfo(message.getLogName(), message.getDescription());
-            ((List)scenarioList).add(soinfo);
+            scenarioList.add(soinfo);
             this.scenariosOrdered.add(soinfo);
         }
     }
@@ -310,10 +310,14 @@ public class GeneralReportWriter implements ReportWriter {
                 StringEscapeUtils.escapeXml(si.name)));
             if (si.level == 40000) {
                 if ("true".equals(Config.getString("report.junit.ci.url"))) {
-                    sb.append("<failure type=\"\"  message=\"" + Config.getString("report.detailed.path")
-                            + this.getFolderByScenarioName(si.getName()) + "/report.html\"/>");
+                    sb.append("<failure type=\"\"  message=\"")
+                            .append(Config.getString("report.detailed.path"))
+                            .append(this.getFolderByScenarioName(si.getName()))
+                            .append("/report.html\"/>");
                 } else {
-                    sb.append("<failure type=\"\">" + StringEscapeUtils.escapeXml(si.getCause()) + "</failure>");
+                    sb.append("<failure type=\"\">")
+                            .append(StringEscapeUtils.escapeXml(si.getCause()))
+                            .append("</failure>");
                 }
             }
         }
@@ -323,10 +327,7 @@ public class GeneralReportWriter implements ReportWriter {
 
     public String getFolderByScenarioName(String name) {
         String[] arr$ = getWebReportDir().list();
-        int len$ = arr$.length;
-
-        for(int i$ = 0; i$ < len$; ++i$) {
-            String folder = arr$[i$];
+        for (String folder : arr$) {
             if (folder.contains(name)) {
                 return folder;
             }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/InterruptScenarioException.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/InterruptScenarioException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.qubership.atp.adapter.report;
 
+import java.io.Serial;
+
 public class InterruptScenarioException extends RuntimeException {
-    private static final long serialVersionUID = 5118522519220527563L;
+  @Serial
+  private static final long serialVersionUID = 5118522519220527563L;
 
     public InterruptScenarioException(String description, Throwable cause) {
         super(description, cause);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/Report.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/Report.java
@@ -33,9 +33,9 @@ import org.qubership.atp.adapter.testcase.Config;
 
 public class Report {
     private static Report instance;
-    private Queue<ReportWriter> reportWriters = new ConcurrentLinkedQueue();
-    private Queue<ReportAdapter> reportAdapters = new ConcurrentLinkedQueue();
-    private static ThreadLocal<Boolean> init = new ThreadLocal();
+    private final Queue<ReportWriter> reportWriters = new ConcurrentLinkedQueue<>();
+    private final Queue<ReportAdapter> reportAdapters = new ConcurrentLinkedQueue<>();
+    private static final ThreadLocal<Boolean> init = new ThreadLocal<>();
 
     private Report() {
     }
@@ -100,74 +100,67 @@ public class Report {
     }
 
     public void message(Object item) {
-        Iterator reportAdapterIterator = this.reportAdapters.iterator();
-
-        while(reportAdapterIterator.hasNext()) {
-            ReportAdapter adapter = (ReportAdapter)reportAdapterIterator.next();
-            Iterator reportWriterIterator = this.reportWriters.iterator();
-
-            while(reportWriterIterator.hasNext()) {
-                ReportWriter report = (ReportWriter)reportWriterIterator.next();
+        for (ReportAdapter adapter : this.reportAdapters) {
+            for (ReportWriter report : this.reportWriters) {
                 adapter.write(report, item);
             }
         }
-
     }
 
     public void info(String title) {
-        this.info(title, title, (SourceProvider)null);
+        this.info(title, title, null);
     }
 
     public void info(String title, String message) {
-        this.info(title, message, (SourceProvider)null);
+        this.info(title, message, null);
     }
 
     public void info(String title, String message, SourceProvider page) {
-        this.info(title, message, (LinkedHashMap)null, page);
+        this.info(title, message, null, page);
     }
 
     public void info(String title, String message, LinkedHashMap<Object, Object> addValues, SourceProvider page) {
-        this.message(title, Level.INFO, message, addValues, (Throwable)null, page);
+        this.message(title, Level.INFO, message, addValues, null, page);
     }
 
     public void warn(String title) {
-        this.warn(title, title, (SourceProvider)null);
+        this.warn(title, title, null);
     }
 
     public void warn(String title, String message) {
-        this.warn(title, message, (SourceProvider)null);
+        this.warn(title, message, null);
     }
 
     public void warn(String title, String message, SourceProvider page) {
-        this.warn(title, message, (LinkedHashMap)null, page);
+        this.warn(title, message, null, page);
     }
 
     public void warn(String title, String message, LinkedHashMap<Object, Object> addValues, SourceProvider page) {
-        this.message(title, Level.WARN, message, addValues, (Throwable)null, page);
+        this.message(title, Level.WARN, message, addValues, null, page);
     }
 
     public void error(String title) {
-        this.error(title, (String)title, (SourceProvider)null);
+        this.error(title, title, null);
     }
 
     public void error(String title, String message) {
-        this.error(title, (String)message, (SourceProvider)null);
+        this.error(title, message, null);
     }
 
     public void error(String title, Throwable t) {
-        this.error(title, (Throwable)t, (SourceProvider)null);
+        this.error(title, t, null);
     }
 
     public void error(String title, Throwable t, SourceProvider page) {
-        this.error(title, "", (LinkedHashMap)null, t, page);
+        this.error(title, "", null, t, page);
     }
 
     public void error(String title, String message, SourceProvider page) {
-        this.error(title, message, (LinkedHashMap)null, (Throwable)null, page);
+        this.error(title, message, null, null, page);
     }
 
     public void error(String title, String message, LinkedHashMap<Object, Object> addValues, SourceProvider page) {
-        this.error(title, message, addValues, (Throwable)null, page);
+        this.error(title, message, addValues, null, page);
     }
 
     public void error(String title, String message, LinkedHashMap<Object, Object> addValues, Throwable t, SourceProvider page) {
@@ -175,7 +168,7 @@ public class Report {
     }
 
     private void message(String title, Level level, String message, Throwable throwable, SourceProvider page) {
-        this.message(title, level, message, (LinkedHashMap)null, throwable, page);
+        this.message(title, level, message, null, throwable, page);
     }
 
     private void message(String title, Level level, String message, LinkedHashMap<Object, Object> addValues, Throwable throwable, SourceProvider page) {
@@ -199,7 +192,7 @@ public class Report {
     }
 
     public void openSection(String sectionName, String message, SourceProvider page) {
-        this.openSection(sectionName, message, (LinkedHashMap)null, page);
+        this.openSection(sectionName, message, null, page);
     }
 
     public void openSection(String sectionName, String message, LinkedHashMap<Object, Object> addValues, SourceProvider page) {
@@ -212,18 +205,14 @@ public class Report {
 
     public File getReportDir() {
         AbstractWebReportWriter abstractWebReportWriter = null;
-        Iterator i$ = this.reportWriters.iterator();
-
-        while(i$.hasNext()) {
-            ReportWriter reportWriter = (ReportWriter)i$.next();
+        for (ReportWriter reportWriter : this.reportWriters) {
             if (reportWriter instanceof WebReportWriterWraper webReportWriterWraper) {
                 abstractWebReportWriter = webReportWriterWraper.getWebReportWriter();
             } else if (reportWriter instanceof AbstractWebReportWriter writer) {
                 abstractWebReportWriter = writer;
             }
         }
-
-        return abstractWebReportWriter == null ? null : ((AbstractWebReportWriter)abstractWebReportWriter).getReportDir();
+        return abstractWebReportWriter == null ? null : abstractWebReportWriter.getReportDir();
     }
 
     static {
@@ -242,7 +231,6 @@ public class Report {
             getReport().addWriter(new GeneralReportWriter());
             getReport().addAdapter(new GeneralReportWriterAdapter());
         }
-
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/Report.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/Report.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,13 @@
 
 package org.qubership.atp.adapter.report;
 
+import java.io.File;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.log4j.Level;
 import org.qubership.atp.adapter.report.adapter.GeneralReportWriterAdapter;
 import org.qubership.atp.adapter.report.adapter.WebReportWriterAdapter;
 import org.qubership.atp.adapter.report.adapter.WebReportWriterDiffAdapter;
@@ -23,12 +30,6 @@ import org.qubership.atp.adapter.report.adapter.WebReportWriterJointAdapter;
 import org.qubership.atp.adapter.report.rmi.RemoteParametersStorage;
 import org.qubership.atp.adapter.report.rmi.WebReportWriterWrapperRemote;
 import org.qubership.atp.adapter.testcase.Config;
-import java.io.File;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import org.apache.log4j.Level;
 
 public class Report {
     private static Report instance;
@@ -215,11 +216,10 @@ public class Report {
 
         while(i$.hasNext()) {
             ReportWriter reportWriter = (ReportWriter)i$.next();
-            if (reportWriter instanceof WebReportWriterWraper) {
-                WebReportWriterWraper webReportWriterWraper = (WebReportWriterWraper)reportWriter;
+            if (reportWriter instanceof WebReportWriterWraper webReportWriterWraper) {
                 abstractWebReportWriter = webReportWriterWraper.getWebReportWriter();
-            } else if (reportWriter instanceof AbstractWebReportWriter) {
-                abstractWebReportWriter = (AbstractWebReportWriter)reportWriter;
+            } else if (reportWriter instanceof AbstractWebReportWriter writer) {
+                abstractWebReportWriter = writer;
             }
         }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriter.java
@@ -16,7 +16,6 @@
 
 package org.qubership.atp.adapter.report;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -25,7 +24,6 @@ import java.nio.channels.FileChannel;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -54,28 +52,28 @@ public class WebReportWriter extends AbstractWebReportWriter {
     private static final String LOG_REPORT_SNAPSHOTS = "report.log.snapshots";
     private static final String SPLIT_REPORT = "report.split.enable";
     private static final boolean SHOW_PAGE_SOURCES;
-    private static ReportThreadLocal report;
-    private static ArrayList<File> snapshotFiles;
-    private static ThreadLocal<String> reportFiles;
+    private static final ReportThreadLocal report;
+    private static final ArrayList<File> snapshotFiles;
+    private static final ThreadLocal<String> reportFiles;
     private String reportEncoding;
-    private Stack<String> currentLogCallStack = new Stack();
+    private final Stack<String> currentLogCallStack = new Stack<>();
     private String currentLogName = null;
     private int msgId = 0;
     private int maxPriorityReported = 20000;
-    private Stack<Long> timeStack = new Stack();
+    private final Stack<Long> timeStack = new Stack<>();
     private File reportFile;
     private long reportFileLength;
     private long indexPosition;
     private File reportDir;
     private boolean logReportSnapshots = false;
     private String description = "";
-    private List<Logger> customLoggers;
+    private final List<Logger> customLoggers;
     private int logId = 0;
     private int pageId = 0;
     private int reportCounter = 0;
     private boolean isInit = false;
-    private static String reportJarDir;
-    private String threadName = Thread.currentThread().getName();
+    private static final String reportJarDir;
+    private final String threadName = Thread.currentThread().getName();
 
     public String getThreadName() {
         return this.threadName;
@@ -127,7 +125,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
     }
 
     private static WebReportWriter reportToThreadlocal(WebReportWriter report) {
-        report = new WebReportWriter((Properties)null);
+        report = new WebReportWriter(null);
         WebReportWriter.report.set(report);
         return report;
     }
@@ -149,7 +147,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
 
     public synchronized void openLog(String logName, String description) {
         if (Boolean.parseBoolean(Config.getString("report.split.enable"))) {
-            this.createReportDir((Properties)null);
+            this.createReportDir(null);
         }
 
         if (!this.isInit || Boolean.parseBoolean(Config.getString("report.split.enable"))) {
@@ -190,7 +188,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
                 this.appendReportFile(this.formatMessageClose());
             }
 
-            this.appendReportFile(this.formatMessageTime((Long)this.timeStack.lastElement(), System.currentTimeMillis()) + "</LOG>");
+            this.appendReportFile(this.formatMessageTime(this.timeStack.lastElement(), System.currentTimeMillis()) + "</LOG>");
             FileChannel indexFileChannel = null;
 
             try {
@@ -201,7 +199,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
             } catch (IOException var6) {
                 log.error("Unable to write to index file", var6);
             } finally {
-                Utils.close(new Closeable[]{indexFileChannel});
+                Utils.close(indexFileChannel);
             }
 
         }
@@ -209,12 +207,10 @@ public class WebReportWriter extends AbstractWebReportWriter {
 
     public synchronized void openSection(String sectionName, String message, SourceProvider page, LinkedHashMap<Object, Object> addValues) {
         this.currentLogCallStack.push(sectionName);
-        this.appendReportFile(this.formatMessageOpen(sectionName, (Level)null, message, page, addValues), this.reportFileLength);
-        Iterator i$ = this.customLoggers.iterator();
+        this.appendReportFile(this.formatMessageOpen(sectionName, null, message, page, addValues), this.reportFileLength);
 
-        while(i$.hasNext()) {
-            Logger logger = (Logger)i$.next();
-            logger.info(this.currentLogCallStack.toString() + " Section - " + sectionName);
+        for (Logger logger : this.customLoggers) {
+            logger.info(this.currentLogCallStack + " Section - " + sectionName);
         }
 
         this.timeStack.push(System.currentTimeMillis());
@@ -224,23 +220,21 @@ public class WebReportWriter extends AbstractWebReportWriter {
     public synchronized void closeSection() {
         if (!this.currentLogCallStack.isEmpty()) {
             this.currentLogCallStack.pop();
-            this.appendReportFile(this.formatMessageTime((Long)this.timeStack.pop(), System.currentTimeMillis()) + this.formatMessageClose(), this.reportFileLength);
+            this.appendReportFile(this.formatMessageTime(this.timeStack.pop(), System.currentTimeMillis()) + this.formatMessageClose(), this.reportFileLength);
             this.appendTail();
         }
     }
 
     public synchronized void message(String title, Level level, String message, SourceProvider page) {
-        this.message(title, level, message, page, (LinkedHashMap)null);
+        this.message(title, level, message, page, null);
     }
 
     public synchronized void message(String title, Level level, String message, SourceProvider page, LinkedHashMap<Object, Object> addValues) {
         this.maxPriorityReported = Math.max(this.maxPriorityReported, level.toInt());
         this.appendReportFile(this.formatMessageOpen(title, level, message, page, addValues) + this.formatMessageClose(), this.reportFileLength);
-        String msg = this.currentLogCallStack.toString() + " Title: " + (title == null ? "" : title) + ", Message: " + (message == null ? "" : message);
-        Iterator i$ = this.customLoggers.iterator();
+        String msg = this.currentLogCallStack + " Title: " + (title == null ? "" : title) + ", Message: " + (message == null ? "" : message);
 
-        while(i$.hasNext()) {
-            Logger customerLogger = (Logger)i$.next();
+        for (Logger customerLogger : this.customLoggers) {
             customerLogger.log(level, msg);
         }
 
@@ -287,10 +281,8 @@ public class WebReportWriter extends AbstractWebReportWriter {
 
         if (addValues != null) {
             Pattern NON_ALPHANUMERIC = Pattern.compile("[^a-zA-Z0-9_]*");
-            Iterator i$ = addValues.keySet().iterator();
 
-            while(i$.hasNext()) {
-                Object keyO = i$.next();
+            for (Object keyO : addValues.keySet()) {
                 String key;
                 if (!(key = NON_ALPHANUMERIC.matcher(keyO.toString()).replaceAll("")).isEmpty()) {
                     result.append(" %s=\"%s\"".formatted(key, addValues.get(keyO).toString()));
@@ -299,7 +291,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
         }
 
         result.append(">");
-        result.append("<title><![CDATA[").append(title != null && title.length() > 0 ? title : "[message]").append("]]></title>");
+        result.append("<title><![CDATA[").append(title != null && !title.isEmpty() ? title : "[message]").append("]]></title>");
         result.append("<message><![CDATA[").append(message).append("]]></message>");
         return result.toString();
     }
@@ -323,11 +315,11 @@ public class WebReportWriter extends AbstractWebReportWriter {
             int seconds = remainder % 60;
             StringBuilder result = new StringBuilder();
             if (hours > 0) {
-                result.append((hours < 10 ? "0" : "") + hours).append(":");
+                result.append(hours < 10 ? "0" : "").append(hours).append(":");
             }
 
             if (minutes > 0 || hours > 0) {
-                result.append((minutes < 10 ? "0" : "") + minutes).append(":");
+                result.append(minutes < 10 ? "0" : "").append(minutes).append(":");
             }
 
             if (hours <= 0 && minutes <= 0) {
@@ -338,7 +330,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
                     result.append(" seconds");
                 }
             } else {
-                result.append((seconds < 10 ? "0" : "") + seconds);
+                result.append(seconds < 10 ? "0" : "").append(seconds);
             }
 
             return result.toString();
@@ -366,19 +358,16 @@ public class WebReportWriter extends AbstractWebReportWriter {
                 } else {
                     fileChannel.write(ByteBuffer.wrap(dataBytes), fileChannel.size());
                 }
-            } catch (IOException var15) {
-                IOException e = var15;
+            } catch (IOException e) {
                 log.error("Unable to write to " + this.reportFile.getName(), e);
             } finally {
                 try {
                     if (fileChannel != null) {
                         fileChannel.close();
                     }
-                } catch (IOException var14) {
-                    IOException e = var14;
+                } catch (IOException e) {
                     log.error("Unable to close " + this.reportFile.getName(), e);
                 }
-
             }
 
         }
@@ -394,7 +383,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
             return "";
         } else {
             getWebReportWriter();
-            return ((String)reportFiles.get()).replaceAll("report[0-9]*.xml", "report.html");
+            return reportFiles.get().replaceAll("report[0-9]*.xml", "report.html");
         }
     }
 
@@ -409,14 +398,14 @@ public class WebReportWriter extends AbstractWebReportWriter {
     }
 
     private static class ReportThreadLocal extends ThreadLocal<WebReportWriter> {
-        private static boolean isReportThreadLocal = Config.getBoolean("report.thread.local", true);
+        private static final boolean isReportThreadLocal = Config.getBoolean("report.thread.local", true);
         private WebReportWriter report;
 
         private ReportThreadLocal() {
         }
 
         public WebReportWriter get() {
-            return isReportThreadLocal ? (WebReportWriter)super.get() : this.report;
+            return isReportThreadLocal ? super.get() : this.report;
         }
 
         public void set(WebReportWriter value) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.qubership.atp.adapter.report;
 
-import org.qubership.atp.adapter.testcase.Config;
-import org.qubership.atp.adapter.utils.Utils;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -34,10 +32,13 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Stack;
 import java.util.regex.Pattern;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.qubership.atp.adapter.testcase.Config;
+import org.qubership.atp.adapter.utils.Utils;
 
 public class WebReportWriter extends AbstractWebReportWriter {
     private static final Log log = LogFactory.getLog(WebReportWriter.class);
@@ -162,7 +163,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
         }
 
         this.description = description;
-        String filename = "report" + String.format("%04d", this.logId++) + ".xml";
+        String filename = "report" + "%04d".formatted(this.logId++) + ".xml";
         this.currentLogName = logName;
         this.currentLogCallStack.clear();
         this.timeStack.clear();
@@ -247,7 +248,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
     }
 
     private File createSnapshot(SourceProvider page) {
-        String pageFilename = "page" + String.format("%04d", this.pageId++);
+        String pageFilename = "page" + "%04d".formatted(this.pageId++);
         File pageFileHTML = new File(new File(this.reportDir, "pages"), pageFilename + "." + page.getExtension());
         if (this.logReportSnapshots) {
             snapshotFiles.add(pageFileHTML);
@@ -292,7 +293,7 @@ public class WebReportWriter extends AbstractWebReportWriter {
                 Object keyO = i$.next();
                 String key;
                 if (!(key = NON_ALPHANUMERIC.matcher(keyO.toString()).replaceAll("")).isEmpty()) {
-                    result.append(String.format(" %s=\"%s\"", key, addValues.get(keyO).toString()));
+                    result.append(" %s=\"%s\"".formatted(key, addValues.get(keyO).toString()));
                 }
             }
         }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterDiff.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterDiff.java
@@ -119,7 +119,7 @@ public class WebReportWriterDiff extends AbstractWebReportWriter {
         this.log().description = description;
         String filename;
         synchronized(this) {
-            filename = String.format("report%04d", LOG_COUNTER.incrementAndGet()) + ".xml";
+            filename = "report%04d".formatted(LOG_COUNTER.incrementAndGet()) + ".xml";
         }
 
         this.log().currentLogName = logName;
@@ -208,7 +208,7 @@ public class WebReportWriterDiff extends AbstractWebReportWriter {
 
     private String createSnapshot(SourceProvider page) {
         Long startTime = System.currentTimeMillis();
-        String pageFilename = "page" + String.format("%04d", PAGE_COUNTER.incrementAndGet());
+        String pageFilename = "page" + "%04d".formatted(PAGE_COUNTER.incrementAndGet());
         File pageFileHTML = new File(new File(this.reportDir, "pages"), pageFilename + "." + page.getExtension());
         if (this.originName == null) {
             this.originName = pageFileHTML.getName();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterDiff.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterDiff.java
@@ -51,10 +51,10 @@ public class WebReportWriterDiff extends AbstractWebReportWriter {
     public static final String REPORT_THREAD_LOCAL_KEY = "report.thread.local";
     private static final SimpleDateFormat DATE_FORMAT;
     private static final SimpleDateFormat TIME_FORMAT;
-    private static AtomicInteger PAGE_COUNTER;
-    private static AtomicInteger LOG_COUNTER;
-    private static ReportThreadLocal REPORT;
-    private static String REPORT_JAR_DIR;
+    private static final AtomicInteger PAGE_COUNTER;
+    private static final AtomicInteger LOG_COUNTER;
+    private static final ReportThreadLocal REPORT;
+    private static final String REPORT_JAR_DIR;
     private String reportEncoding;
     private File reportDir;
     private List<Logger> customLoggers;
@@ -176,7 +176,7 @@ public class WebReportWriterDiff extends AbstractWebReportWriter {
 
     public synchronized void openSection(String sectionName, String message, SourceProvider page) {
         this.log().currentLogCallStack.push(sectionName);
-        this.appendReportFile(this.formatMessageOpen(sectionName, (Level)null, message, page), this.log().reportFileLength);
+        this.appendReportFile(this.formatMessageOpen(sectionName, null, message, page), this.log().reportFileLength);
 
         for (Logger logger : this.customLoggers) {
             logger.info(this.log().currentLogCallStack.toString() + "Section - " + sectionName);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterJoint.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterJoint.java
@@ -169,7 +169,7 @@ public class WebReportWriterJoint extends AbstractWebReportWriter {
 
     public synchronized void openSection(String sectionName, String message, SourceProvider page) {
         this.log().currentLogCallStack.push(sectionName);
-        this.appendReportFile(this.formatMessageOpen(sectionName, (Level)null, message, page), this.log().reportFileLength);
+        this.appendReportFile(this.formatMessageOpen(sectionName, null, message, page), this.log().reportFileLength);
 
         for (Logger logger : this.customLoggers) {
             logger.info(this.log().currentLogCallStack.toString() + " Section - " + sectionName);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterJoint.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/WebReportWriterJoint.java
@@ -112,7 +112,7 @@ public class WebReportWriterJoint extends AbstractWebReportWriter {
         this.log().description = description;
         String fileName;
         synchronized(this) {
-            fileName = "report" + String.format("%04d", ResourcesManager.getLogCounter()) + ".xml";
+            fileName = "report" + "%04d".formatted(ResourcesManager.getLogCounter()) + ".xml";
         }
 
         this.log().currentLogName = logName;
@@ -200,7 +200,7 @@ public class WebReportWriterJoint extends AbstractWebReportWriter {
     }
 
     private File createSnapshot(SourceProvider page) {
-        String pageFileName = "page" + String.format("%04d", ResourcesManager.getPageCounter());
+        String pageFileName = "page" + "%04d".formatted(ResourcesManager.getPageCounter());
         File pageFileHTML = new File(new File(this.reportDir, "pages"), pageFileName + "." + page.getExtension());
         if (this.logReportSnapshots) {
             snapshotFiles.add(pageFileHTML);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/GeneralReportWriterAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/GeneralReportWriterAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ public class GeneralReportWriterAdapter extends GenericsReportAdapter<GeneralRep
 
     public void writeItem(GeneralReportWriter writer, Object item) {
         try {
-            if (item instanceof WebReportItem.Message) {
-                writer.report((WebReportItem.Message)item, Thread.currentThread());
-            } else if (item instanceof WebReportItem.OpenLog) {
-                writer.newScenario((WebReportItem.OpenLog)item, Thread.currentThread());
+            if (item instanceof WebReportItem.Message message) {
+                writer.report(message, Thread.currentThread());
+            } else if (item instanceof WebReportItem.OpenLog log) {
+                writer.newScenario(log, Thread.currentThread());
             }
         } finally {
             writer.reportScenarioDetails();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ public class WebReportWriterAdapter extends GenericsReportAdapter<WebReportWrite
     }
 
     public void writeItem(WebReportWriterWraper writer, Object item) {
-        if (item instanceof WebReportItem) {
-            ((WebReportItem)item).message(writer);
+        if (item instanceof WebReportItem reportItem) {
+            reportItem.message(writer);
         }
 
     }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterDiffAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterDiffAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,21 +26,18 @@ public class WebReportWriterDiffAdapter extends GenericsReportAdapter<WebReportW
     }
 
     public void writeItem(WebReportWriterDiff writer, Object item) {
-        if (item instanceof WebReportItem.Message) {
-            WebReportItem.Message msg = (WebReportItem.Message)item;
+        if (item instanceof WebReportItem.Message msg) {
             StringBuilder message = new StringBuilder(msg.getMessage());
             if (msg.getThrowable() != null) {
                 message.append("<pre>").append(Utils.getStackTrace(msg.getThrowable())).append("</pre>");
             }
 
             writer.message(msg.getTitle(), msg.getLevel(), message.toString(), msg.getPage());
-        } else if (item instanceof WebReportItem.OpenSection) {
-            WebReportItem.OpenSection os = (WebReportItem.OpenSection)item;
+        } else if (item instanceof WebReportItem.OpenSection os) {
             writer.openSection(os.getTitle(), os.getMessage(), os.getPage());
         } else if (item instanceof WebReportItem.CloseSection) {
             writer.closeSection();
-        } else if (item instanceof WebReportItem.OpenLog) {
-            WebReportItem.OpenLog ol = (WebReportItem.OpenLog)item;
+        } else if (item instanceof WebReportItem.OpenLog ol) {
             writer.openLog(ol.getLogName(), ol.getDescription());
         } else if (item instanceof WebReportItem.CloseLog) {
             writer.closeLog();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterJointAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/adapter/WebReportWriterJointAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,21 +26,18 @@ public class WebReportWriterJointAdapter extends GenericsReportAdapter<WebReport
     }
 
     public void writeItem(WebReportWriterJoint writer, Object item) {
-        if (item instanceof WebReportItem.Message) {
-            WebReportItem.Message msg = (WebReportItem.Message)item;
+        if (item instanceof WebReportItem.Message msg) {
             StringBuilder message = new StringBuilder(msg.getMessage());
             if (msg.getThrowable() != null) {
                 message.append("<pre>").append(Utils.getStackTrace(msg.getThrowable())).append("</pre>");
             }
 
             writer.message(msg.getTitle(), msg.getLevel(), message.toString(), msg.getPage());
-        } else if (item instanceof WebReportItem.OpenSection) {
-            WebReportItem.OpenSection os = (WebReportItem.OpenSection)item;
+        } else if (item instanceof WebReportItem.OpenSection os) {
             writer.openSection(os.getTitle(), os.getMessage(), os.getPage());
         } else if (item instanceof WebReportItem.CloseSection) {
             writer.closeSection();
-        } else if (item instanceof WebReportItem.OpenLog) {
-            WebReportItem.OpenLog ol = (WebReportItem.OpenLog)item;
+        } else if (item instanceof WebReportItem.OpenLog ol) {
             writer.openLog(ol.getLogName(), ol.getDescription());
         } else if (item instanceof WebReportItem.CloseLog) {
             writer.closeLog();

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/rmi/LocalToRemoteReportAdapter.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/report/rmi/LocalToRemoteReportAdapter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,30 +16,30 @@
 
 package org.qubership.atp.adapter.report.rmi;
 
+import java.rmi.RemoteException;
+import java.rmi.server.UnicastRemoteObject;
+
 import org.qubership.atp.adapter.report.WebReportItem;
 import org.qubership.atp.adapter.report.WebReportWriterDiff;
 import org.qubership.atp.adapter.report.WebReportWriterWraper;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.utils.Utils;
-import java.rmi.RemoteException;
-import java.rmi.server.UnicastRemoteObject;
 
 public class LocalToRemoteReportAdapter extends UnicastRemoteObject implements RemoteReportAdapter {
-    private WebReportWriterWraper wraper = new WebReportWriterWraper();
-    private WebReportWriterDiff writer = new WebReportWriterDiff();
-    private String threadName;
+    private final WebReportWriterWraper wrapper = new WebReportWriterWraper();
+    private final WebReportWriterDiff writer = new WebReportWriterDiff();
+    private final String threadName;
 
     public LocalToRemoteReportAdapter(String threadName) throws RemoteException {
         this.threadName = threadName;
     }
 
     public void write(Object item) throws RemoteException {
-        if (item instanceof WebReportItem) {
+        if (item instanceof WebReportItem reportItem) {
             String oldThreadName = Thread.currentThread().getName();
             Thread.currentThread().setName(this.threadName);
             if (Config.getBoolean("use.diff.report", false)) {
-                if (item instanceof WebReportItem.Message) {
-                    WebReportItem.Message msg = (WebReportItem.Message)item;
+                if (item instanceof WebReportItem.Message msg) {
                     StringBuilder message = new StringBuilder(msg.getMessage());
                     if (msg.getThrowable() != null) {
                         message.append("<pre>").append(Utils.getStackTrace(msg.getThrowable())).append("</pre>");
@@ -48,7 +48,7 @@ public class LocalToRemoteReportAdapter extends UnicastRemoteObject implements R
                     this.writer.message(msg.getTitle(), msg.getLevel(), message.toString(), msg.getPage());
                 }
             } else {
-                ((WebReportItem)item).message(this.wraper);
+                reportItem.message(this.wrapper);
             }
 
             Thread.currentThread().setName(oldThreadName);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/testcase/Config.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/testcase/Config.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.qubership.atp.adapter.testcase;
 
-import org.qubership.atp.adapter.utils.Utils;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -32,12 +31,15 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.qubership.atp.adapter.utils.Utils;
 
 public class Config {
     private static final Log log = LogFactory.getLog(Config.class);
@@ -85,7 +87,7 @@ public class Config {
                 return Integer.parseInt(getString(key));
             } catch (NumberFormatException var3) {
                 NumberFormatException e = var3;
-                log.warn(String.format("'%s' value should be a number. Actual value is '%s'", key, getString(key)), e);
+                log.warn("'%s' value should be a number. Actual value is '%s'".formatted(key, getString(key)), e);
                 return defaultValue;
             }
         } else {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/testcase/Config.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/testcase/Config.java
@@ -17,7 +17,6 @@
 package org.qubership.atp.adapter.testcase;
 
 import java.io.BufferedReader;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -85,8 +84,7 @@ public class Config {
         if (!getString(key).trim().isEmpty()) {
             try {
                 return Integer.parseInt(getString(key));
-            } catch (NumberFormatException var3) {
-                NumberFormatException e = var3;
+            } catch (NumberFormatException e) {
                 log.warn("'%s' value should be a number. Actual value is '%s'".formatted(key, getString(key)), e);
                 return defaultValue;
             }
@@ -169,9 +167,9 @@ public class Config {
                 String line;
                 while((line = lines.readLine()) != null) {
                     line = line.trim();
-                    if (!line.startsWith("#") && line.length() != 0) {
+                    if (!line.startsWith("#") && !line.isEmpty()) {
                         Matcher m = PARAMETRIZATION_PATTERN.matcher(line);
-                        StringBuffer resultLine = new StringBuffer();
+                        StringBuilder resultLine = new StringBuilder();
 
                         while(m.find()) {
                             String key = m.group(1);
@@ -199,12 +197,11 @@ public class Config {
                         }
                     }
                 }
-            } catch (IOException var11) {
-                IOException e = var11;
+            } catch (IOException e) {
                 log.fatal("Failed to read properties file: " + propertiesFile.getName(), e);
                 throw new RuntimeException("IOException", e);
             } finally {
-                Utils.close(new Closeable[]{lines});
+                Utils.close(lines);
             }
 
             return p;
@@ -234,8 +231,7 @@ public class Config {
             factory.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             factory.setNamespaceAware(true);
             builder = factory.newDocumentBuilder();
-        } catch (ParserConfigurationException var2) {
-            ParserConfigurationException e = var2;
+        } catch (ParserConfigurationException e) {
             log.fatal("ParserConfigurationException", e);
             throw new RuntimeException("ParserConfigurationException", e);
         }
@@ -250,7 +246,7 @@ public class Config {
         }
 
         String timeZoneId = getString("nc.timezone");
-        serverTimeZone = timeZoneId.length() == 0 ? TimeZone.getDefault() : TimeZone.getTimeZone(timeZoneId);
+        serverTimeZone = timeZoneId.isEmpty() ? TimeZone.getDefault() : TimeZone.getTimeZone(timeZoneId);
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/Context.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/Context.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public final class Context {
     private static ContextType defaultContextType;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/Context.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/Context.java
@@ -22,8 +22,8 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 public final class Context {
-    private static ContextType defaultContextType;
-    private static ContextType globalContextType;
+    private static final ContextType defaultContextType;
+    private static final ContextType globalContextType;
 
     public Context() {
     }
@@ -92,4 +92,3 @@ public final class Context {
         globalContextType = ContextType.GLOBAL;
     }
 }
-

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextDataStorage.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextDataStorage.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import com.google.common.eventbus.EventBus;
 import java.io.Externalizable;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import com.google.common.eventbus.EventBus;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public interface ContextDataStorage extends Externalizable {
     <T> ContextRecord<T> putValue(@Nonnull String var1, @Nullable T var2);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextDataStorageProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextDataStorageProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 public interface ContextDataStorageProvider {
     @Nullable

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import com.google.common.base.Preconditions;
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeModel;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 abstract class ContextProvider implements ContextDataStorageProvider {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextProvider.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Nullable;
 
 abstract class ContextProvider implements ContextDataStorageProvider {
     @Nonnull
-    private ScopeModel scopeModel;
+    private final ScopeModel scopeModel;
 
     public ContextProvider(@Nonnull ScopeModel scopeModel) {
         Preconditions.checkNotNull(scopeModel, "Scope model cannot be null");
@@ -47,14 +47,11 @@ abstract class ContextProvider implements ContextDataStorageProvider {
 
     @Nonnull
     public ContextDataStorage getContextDataStorage() {
-        switch (this.getScopeModel()) {
-            case SINGLE:
-                return this.getForSingleScopeMode();
-            case MULTI:
-                return this.getForMultiScopeMode();
-            default:
-                return this.getForPrimitive();
-        }
+        return switch (this.getScopeModel()) {
+            case SINGLE -> this.getForSingleScopeMode();
+            case MULTI -> this.getForMultiScopeMode();
+            default -> this.getForPrimitive();
+        };
     }
 
     @Nullable
@@ -62,7 +59,6 @@ abstract class ContextProvider implements ContextDataStorageProvider {
         ThreadGroup threadGroup;
         for(threadGroup = Thread.currentThread().getThreadGroup(); !targetProviderClass.isAssignableFrom(threadGroup.getClass()) && threadGroup.getParent() != null; threadGroup = threadGroup.getParent()) {
         }
-
         return targetProviderClass.isAssignableFrom(threadGroup.getClass()) ? ((ContextDataStorageProvider)threadGroup).getContextDataStorage() : null;
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextRecord.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextRecord.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,16 +16,19 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import com.google.common.base.Preconditions;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public final class ContextRecord<T> implements Serializable {
-    private static final long serialVersionUID = -1049577909010590824L;
+  @Serial
+  private static final long serialVersionUID = -1049577909010590824L;
     @Nonnull
     private String key;
     private T value;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextRecord.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextRecord.java
@@ -19,7 +19,6 @@ package org.qubership.atp.adapter.tools.tacomponents.context;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
@@ -27,8 +26,8 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 public final class ContextRecord<T> implements Serializable {
-  @Serial
-  private static final long serialVersionUID = -1049577909010590824L;
+    @Serial
+    private static final long serialVersionUID = -1049577909010590824L;
     @Nonnull
     private String key;
     private T value;
@@ -85,14 +84,12 @@ public final class ContextRecord<T> implements Serializable {
 
     @Nonnull
     public static <T> Map<String, T> convertRecordsToValues(@Nonnull Map<String, ContextRecord<T>> originalMap) {
-        Map<String, T> resultMap = new HashMap();
-        Iterator var2 = originalMap.entrySet().iterator();
+        Map<String, T> resultMap = new HashMap<>();
 
-        while(var2.hasNext()) {
-            Map.Entry<String, ContextRecord<T>> originalEntry = (Map.Entry)var2.next();
-            resultMap.put(originalEntry.getKey(), (T)((ContextRecord)originalEntry.getValue()).getValue());
+        for (Map.Entry<String, ContextRecord<T>> stringContextRecordEntry : originalMap.entrySet()) {
+            resultMap.put(stringContextRecordEntry.getKey(),
+                    (T) ((ContextRecord) stringContextRecordEntry.getValue()).getValue());
         }
-
         return resultMap;
     }
 }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextStorageManager.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextStorageManager.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package org.qubership.atp.adapter.tools.tacomponents.context;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 final class ContextStorageManager {
     private static ContextStorageManager instance;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextStorageManager.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextStorageManager.java
@@ -25,30 +25,24 @@ import jakarta.annotation.Nullable;
 final class ContextStorageManager {
     private static ContextStorageManager instance;
     @Nonnull
-    private final Map<ContextType, ContextDataStorage> storages = new ConcurrentHashMap();
+    private final Map<ContextType, ContextDataStorage> storages = new ConcurrentHashMap<>();
 
     private ContextStorageManager() {
-        ContextType[] var1 = ContextType.values();
-        int var2 = var1.length;
-
-        for(int var3 = 0; var3 < var2; ++var3) {
-            ContextType contextType = var1[var3];
+        for (ContextType contextType : ContextType.values()) {
             this.getStorages().put(contextType, new DefaultContextDataStorage());
         }
-
     }
 
     public static synchronized ContextStorageManager getInstance() {
         if (instance == null) {
             instance = new ContextStorageManager();
         }
-
         return instance;
     }
 
     @Nullable
     public ContextDataStorage getDataStorage(@Nonnull ContextType contextType) {
-        return (ContextDataStorage)this.getStorages().get(contextType);
+        return this.getStorages().get(contextType);
     }
 
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextType.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextType.java
@@ -30,7 +30,7 @@ public enum ContextType {
     @Nonnull
     private static ScopeModel scopeModel = ScopeModel.PRIMITIVE;
 
-    private ContextType(@Nonnull ContextDataStorageProvider contextProvider) {
+    ContextType(@Nonnull ContextDataStorageProvider contextProvider) {
         this.contextProvider = contextProvider;
     }
 
@@ -61,7 +61,7 @@ public enum ContextType {
 
     @Nonnull
     public static ContextProvider produceContextProvider(@Nonnull ContextType contextType, @Nonnull ScopeModel model) {
-        return (ContextProvider)(contextType == GLOBAL ? new GlobalContextProvider(model) : new LocalContextProvider(model));
+        return contextType == GLOBAL ? new GlobalContextProvider(model) : new LocalContextProvider(model);
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextType.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/ContextType.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import com.google.common.base.Preconditions;
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeModel;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public enum ContextType {
     GLOBAL(new GlobalContextProvider(ScopeModel.PRIMITIVE)),

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/DefaultContextDataStorage.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/DefaultContextDataStorage.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,24 +16,28 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Maps;
-import com.google.common.eventbus.EventBus;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serial;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 import org.qubership.atp.adapter.tools.tacomponents.context.events.ClearValuesEvent;
 import org.qubership.atp.adapter.tools.tacomponents.context.events.PutAllValuesEvent;
 import org.qubership.atp.adapter.tools.tacomponents.context.events.PutValueEvent;
 import org.qubership.atp.adapter.tools.tacomponents.context.events.RemoveValueEvent;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
+import com.google.common.eventbus.EventBus;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public class DefaultContextDataStorage implements ContextDataStorage {
-    private static final long serialVersionUID = 6784082206451114536L;
+  @Serial
+  private static final long serialVersionUID = 6784082206451114536L;
     private static final transient Function<ContextRecord<?>, Object> RECORD_TRANSFORMER = new Function<ContextRecord<?>, Object>() {
         @Nullable
         public Object apply(@Nonnull ContextRecord<?> input) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/DefaultContextDataStorage.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/DefaultContextDataStorage.java
@@ -21,7 +21,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serial;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.events.ClearValuesEvent;
@@ -36,9 +35,9 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 public class DefaultContextDataStorage implements ContextDataStorage {
-  @Serial
-  private static final long serialVersionUID = 6784082206451114536L;
-    private static final transient Function<ContextRecord<?>, Object> RECORD_TRANSFORMER = new Function<ContextRecord<?>, Object>() {
+    @Serial
+    private static final long serialVersionUID = 6784082206451114536L;
+    private static final Function<ContextRecord<?>, Object> RECORD_TRANSFORMER = new Function<>() {
         @Nullable
         public Object apply(@Nonnull ContextRecord<?> input) {
             return input.getValue();
@@ -79,12 +78,11 @@ public class DefaultContextDataStorage implements ContextDataStorage {
     }
 
     public <T> void putValues(@Nonnull Map<String, T> rawMap) {
-        Iterator var2 = rawMap.entrySet().iterator();
 
-        while(var2.hasNext()) {
-            Map.Entry<String, T> entry = (Map.Entry)var2.next();
+        for (Map.Entry<String, T> stringTEntry : rawMap.entrySet()) {
+            Map.Entry<String, T> entry = (Map.Entry) stringTEntry;
             if (entry.getKey() != null) {
-                this.putValue((String)entry.getKey(), entry.getValue());
+                this.putValue(entry.getKey(), entry.getValue());
             }
         }
 
@@ -98,7 +96,7 @@ public class DefaultContextDataStorage implements ContextDataStorage {
 
     @Nullable
     public <T> T getValue(@Nonnull String key, @Nonnull T defaultValue) {
-        ContextRecord record = (ContextRecord)this.records.get(key);
+        ContextRecord record = this.records.get(key);
         return record == null ? defaultValue : (T) record.getValue();
     }
 
@@ -127,7 +125,7 @@ public class DefaultContextDataStorage implements ContextDataStorage {
 
     @Nonnull
     public <T> ContextRecord<T> getRecord(@Nonnull String key, @Nonnull ContextRecord<T> defaultRecord) {
-        ContextRecord record = (ContextRecord)this.records.get(key);
+        ContextRecord record = this.records.get(key);
         return record == null ? defaultRecord : record;
     }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/GlobalContextProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/GlobalContextProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package org.qubership.atp.adapter.tools.tacomponents.context;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeModel;
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeThreadGroup;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public final class GlobalContextProvider extends ContextProvider {
     public GlobalContextProvider(@Nonnull ScopeModel scopeModel) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/LocalContextProvider.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/LocalContextProvider.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package org.qubership.atp.adapter.tools.tacomponents.context;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeItemThreadGroup;
 import org.qubership.atp.adapter.tools.tacomponents.context.threading.ScopeModel;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public final class LocalContextProvider extends ContextProvider {
     public LocalContextProvider(@Nonnull ScopeModel scopeModel) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/ClearValuesEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/ClearValuesEvent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.qubership.atp.adapter.tools.tacomponents.context.events;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
-import javax.annotation.Nonnull;
+
+import jakarta.annotation.Nonnull;
 
 public final class ClearValuesEvent extends DataStorageEvent {
     public ClearValuesEvent(@Nonnull ContextDataStorage dataStorage) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/DataStorageEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/DataStorageEvent.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nonnull;
 
 abstract class DataStorageEvent {
     @Nonnull
-    private ContextDataStorage dataStorage;
+    private final ContextDataStorage dataStorage;
 
     DataStorageEvent(@Nonnull ContextDataStorage dataStorage) {
         this.dataStorage = dataStorage;

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/DataStorageEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/DataStorageEvent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.qubership.atp.adapter.tools.tacomponents.context.events;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
-import javax.annotation.Nonnull;
+
+import jakarta.annotation.Nonnull;
 
 abstract class DataStorageEvent {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutAllValuesEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutAllValuesEvent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context.events;
 
-import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
 import java.util.Map;
-import javax.annotation.Nonnull;
+
+import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
+
+import jakarta.annotation.Nonnull;
 
 public final class PutAllValuesEvent<T> extends DataStorageEvent {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutAllValuesEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutAllValuesEvent.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Nonnull;
 
 public final class PutAllValuesEvent<T> extends DataStorageEvent {
     @Nonnull
-    private Map<String, T> map;
+    private final Map<String, T> map;
 
     public PutAllValuesEvent(@Nonnull Map<String, T> rawValues, @Nonnull ContextDataStorage dataStorage) {
         super(dataStorage);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutValueEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutValueEvent.java
@@ -23,8 +23,8 @@ import jakarta.annotation.Nullable;
 
 public final class PutValueEvent<T> extends DataStorageEvent {
     @Nonnull
-    private String key;
-    private T value;
+    private final String key;
+    private final T value;
 
     public PutValueEvent(@Nonnull String key, @Nullable T value, @Nonnull ContextDataStorage dataStorage) {
         super(dataStorage);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutValueEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/PutValueEvent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package org.qubership.atp.adapter.tools.tacomponents.context.events;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public final class PutValueEvent<T> extends DataStorageEvent {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/RemoveValueEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/RemoveValueEvent.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.qubership.atp.adapter.tools.tacomponents.context.events;
 
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
-import javax.annotation.Nonnull;
+
+import jakarta.annotation.Nonnull;
 
 public final class RemoveValueEvent extends DataStorageEvent {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/RemoveValueEvent.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/events/RemoveValueEvent.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Nonnull;
 
 public final class RemoveValueEvent extends DataStorageEvent {
     @Nonnull
-    private String key;
+    private final String key;
 
     public RemoveValueEvent(@Nonnull String key, @Nonnull ContextDataStorage dataStorage) {
         super(dataStorage);

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ContextThreadGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ContextThreadGroup.java
@@ -41,7 +41,7 @@ abstract class ContextThreadGroup extends ThreadGroup implements ContextDataStor
     }
 
     public void setContextDataStorage(@Nullable ContextDataStorage contextDataStorage) {
-        this.contextDataStorage = (ContextDataStorage)(contextDataStorage == null ? new DefaultContextDataStorage() : contextDataStorage);
+        this.contextDataStorage = contextDataStorage == null ? new DefaultContextDataStorage() : contextDataStorage;
     }
 }
 

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ContextThreadGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ContextThreadGroup.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package org.qubership.atp.adapter.tools.tacomponents.context.threading;
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorage;
 import org.qubership.atp.adapter.tools.tacomponents.context.ContextDataStorageProvider;
 import org.qubership.atp.adapter.tools.tacomponents.context.DefaultContextDataStorage;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 abstract class ContextThreadGroup extends ThreadGroup implements ContextDataStorageProvider {
     @Nonnull

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ScopeItemThreadGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ScopeItemThreadGroup.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context.threading;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public class ScopeItemThreadGroup extends ContextThreadGroup {
     public ScopeItemThreadGroup(@Nonnull String name) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ScopeThreadGroup.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/tools/tacomponents/context/threading/ScopeThreadGroup.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.qubership.atp.adapter.tools.tacomponents.context.threading;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public class ScopeThreadGroup extends ContextThreadGroup {
     public ScopeThreadGroup(@Nonnull String name) {

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/utils/KDTUtils.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/utils/KDTUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,6 +16,25 @@
 
 package org.qubership.atp.adapter.utils;
 
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.qubership.atp.adapter.keyworddriven.basicformat.BasicFormatTestSuiteReader;
 import org.qubership.atp.adapter.keyworddriven.basicformat.StringValueSubstitution;
 import org.qubership.atp.adapter.keyworddriven.executable.Executable;
@@ -28,24 +47,6 @@ import org.qubership.atp.adapter.report.SourceProvider;
 import org.qubership.atp.adapter.report.WebReportWriter;
 import org.qubership.atp.adapter.testcase.Config;
 import org.qubership.atp.adapter.wd.shell.browser.ReportType;
-import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.regex.Pattern;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 
 public class KDTUtils {
     public static final String STORE_TEST_CASE_PARAMETERS_SHEET = "Stored Parameters";
@@ -343,8 +344,8 @@ public class KDTUtils {
 
                 for(Executable current = section; current != null; current = current.getParent()) {
                     if (current.getNormalPriorityParams().size() > 0) {
-                        if (current instanceof Section) {
-                            source.append(htmlBold(((Section)current).getFullName()));
+                        if (current instanceof Section section1) {
+                            source.append(htmlBold(section1.getFullName()));
                         } else {
                             source.append(htmlBold(current.getName()));
                         }
@@ -371,8 +372,8 @@ public class KDTUtils {
         for(Iterator var2 = map.keySet().iterator(); var2.hasNext(); buf.append(htmlRow(key.toString(), value))) {
             key = var2.next();
             Object objValue = map.get(key);
-            if (objValue instanceof Map) {
-                value = mapToTable((Map)objValue);
+            if (objValue instanceof Map map1) {
+                value = mapToTable(map1);
             } else {
                 value = String.valueOf(objValue).replaceAll(" ", "&nbsp;");
             }

--- a/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/utils/KDTUtils.java
+++ b/qubership-atp-adapter-executor/src/main/java/org/qubership/atp/adapter/utils/KDTUtils.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -58,7 +59,7 @@ public class KDTUtils {
     }
 
     public static String prepareFilePath(String file) {
-        String FILE_SEPARATOR = System.getProperty("file.separator");
+        String FILE_SEPARATOR = FileSystems.getDefault().getSeparator();
         if (!FILE_SEPARATOR.equals("\\")) {
             file = file.replaceAll("\\\\", FILE_SEPARATOR);
         }
@@ -97,14 +98,11 @@ public class KDTUtils {
         if (configMap.size() <= 0) {
             return false;
         } else {
-            Iterator var3 = configMap.entrySet().iterator();
-
-            while(var3.hasNext()) {
-                Map.Entry<String, String> entry = (Map.Entry)var3.next();
-                String key = ((String)entry.getKey()).replaceFirst(prefix + ".", "");
-                Config.setString(key, (String)entry.getValue());
+            for (Map.Entry<String, String> stringStringEntry : configMap.entrySet()) {
+                Map.Entry<String, String> entry = (Map.Entry) stringStringEntry;
+                String key = entry.getKey().replaceFirst(prefix + ".", "");
+                Config.setString(key, entry.getValue());
             }
-
             return true;
         }
     }
@@ -114,7 +112,7 @@ public class KDTUtils {
     }
 
     public static String getFileNameFromPath(String filePath) {
-        return filePath.substring(filePath.lastIndexOf(BasicFormatTestSuiteReader.FILE_SEPARATOR) + 1, filePath.length());
+        return filePath.substring(filePath.lastIndexOf(BasicFormatTestSuiteReader.FILE_SEPARATOR) + 1);
     }
 
     public static String getRepTitle() {
@@ -138,20 +136,19 @@ public class KDTUtils {
     }
 
     public static String getRepDesc(String additionalInfo) {
-        return getRepDesc() + (additionalInfo == null ? "" : "" + additionalInfo);
+        return getRepDesc() + (additionalInfo == null ? "" : additionalInfo);
     }
 
     public static String getRepDesc(Keyword e, String additionalInfo) {
-        return getRepDesc(e) + (additionalInfo == null ? "" : "" + additionalInfo);
+        return getRepDesc(e) + (additionalInfo == null ? "" : additionalInfo);
     }
 
     public static Properties getAllConfigContent() {
         try {
             Field config = Config.class.getDeclaredField("config");
             config.setAccessible(true);
-            return (Properties)config.get((Object)null);
-        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException | SecurityException var1) {
-            Exception e = var1;
+            return (Properties)config.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException | SecurityException e) {
             log.error(KDTUtils.class.toString(), e);
             return null;
         }
@@ -163,28 +160,18 @@ public class KDTUtils {
 
     public static String htmlRow(boolean success, Object... cellValues) {
         StringBuilder buf = new StringBuilder("<tr>");
-        Object[] var3 = cellValues;
-        int var4 = cellValues.length;
-
-        for(int var5 = 0; var5 < var4; ++var5) {
-            Object value = var3[var5];
+        for (Object value : cellValues) {
             buf.append("<td").append(success ? ">" : " class='errorBackGround'>").append(value).append("</td>");
         }
-
         buf.append("</tr>");
         return buf.toString();
     }
 
     public static String htmlRow(HtmlClass clazz, Object... cellValues) {
         StringBuilder buf = (new StringBuilder("<tr class='")).append(clazz).append("'>");
-        Object[] var3 = cellValues;
-        int var4 = cellValues.length;
-
-        for(int var5 = 0; var5 < var4; ++var5) {
-            Object value = var3[var5];
+        for (Object value : cellValues) {
             buf.append("<td class='").append(clazz).append("'>").append(value).append("</td>");
         }
-
         buf.append("</tr>");
         return buf.toString();
     }
@@ -199,14 +186,9 @@ public class KDTUtils {
 
     public static String htmlTable(HtmlClass clazz, String... content) {
         StringBuilder buf = (new StringBuilder("<style type='text/css'>\r\ntable.colored {border: 0px; } table.colored th {background-color: #CCCCCC; } table.colored td {white-space: pre-wrap; } table.colored .errorBorder { border-color: coral;} table.colored .errorBackGround { background-color: #F78181;} table.colored .warnBorder { border-color: #FFFF00;} table.colored .warnBackGround { background-color: #FFFF00;} table.colored .successBorder { border-color: #81F781;} table.colored .successBackGround { background-color: #81F781;} table.colored .normal { border-width: 0px;} </style> ")).append("<table class='").append(clazz).append("'><tbody>");
-        String[] var3 = content;
-        int var4 = content.length;
-
-        for(int var5 = 0; var5 < var4; ++var5) {
-            String row = var3[var5];
+        for (String row : content) {
             buf.append(row);
         }
-
         buf.append("</tbody></table>");
         return buf.toString();
     }
@@ -234,8 +216,7 @@ public class KDTUtils {
                 String relativePath = getRelativePath(f.getAbsolutePath(),
                         (new File("../../../QubershipWebApp/")).getAbsolutePath(), File.separator);
                 return Config.getString("server.url") + File.separator + relativePath;
-            } catch (Throwable var3) {
-                Throwable e = var3;
+            } catch (Throwable e) {
                 log.error("Can't get relative link to file " + f.getAbsolutePath(), e);
                 return "";
             }
@@ -244,11 +225,11 @@ public class KDTUtils {
 
     public static String getHostname() {
         String hostname = System.getenv("HOSTNAME");
-        if (hostname != null && !hostname.trim().equals("")) {
+        if (hostname != null && !hostname.trim().isEmpty()) {
             return hostname;
         } else {
             hostname = System.getenv("COMPUTERNAME");
-            return hostname != null && !hostname.trim().equals("") ? hostname : "UNKNOWN-HOST";
+            return hostname != null && !hostname.trim().isEmpty() ? hostname : "UNKNOWN-HOST";
         }
     }
 
@@ -309,7 +290,7 @@ public class KDTUtils {
     public static String getHrefFromId(BigInteger id, String tab) {
         tab = tab.trim().replace(" ", "+");
         String link = id == null ? "#" : "/ncobject.jsp?id=" + id;
-        if (tab.length() != 0) {
+        if (!tab.isEmpty()) {
             link = link + "&tab=" + (tab.charAt(0) != '_' ? "_" : "") + tab;
         }
 
@@ -318,7 +299,7 @@ public class KDTUtils {
 
     public static String htmlLink(String href, String linkName) {
         String color = "#6666FF";
-        if (linkName == null || linkName.length() == 0) {
+        if (linkName == null || linkName.isEmpty()) {
             linkName = "N/A";
             color = "#CC3333";
         }
@@ -343,7 +324,7 @@ public class KDTUtils {
                 source.append("<H1></H1>");
 
                 for(Executable current = section; current != null; current = current.getParent()) {
-                    if (current.getNormalPriorityParams().size() > 0) {
+                    if (!current.getNormalPriorityParams().isEmpty()) {
                         if (current instanceof Section section1) {
                             source.append(htmlBold(section1.getFullName()));
                         } else {
@@ -384,22 +365,13 @@ public class KDTUtils {
 
     public static String listToTable(List<String[]> list) {
         StringBuilder buf = new StringBuilder();
-        Iterator var2 = list.iterator();
-
-        while(var2.hasNext()) {
-            String[] row = (String[])var2.next();
+        for (String[] row : list) {
             buf.append("<tr>");
-            String[] var4 = row;
-            int var5 = row.length;
-
-            for(int var6 = 0; var6 < var5; ++var6) {
-                String cell = var4[var6];
-                buf.append(htmlCell(StringEscapeUtils.escapeHtml4(cell), KDTUtils.HtmlClass.normal));
+            for (String cell : row) {
+                buf.append(htmlCell(StringEscapeUtils.escapeHtml4(cell), HtmlClass.normal));
             }
-
             buf.append("</tr>");
         }
-
         return htmlTable(KDTUtils.HtmlClass.colored, buf.toString());
     }
 
@@ -409,8 +381,8 @@ public class KDTUtils {
 
     private static Map<String, Object> getFinalPropTableNormal(Executable section) {
         Map<String, Object> finalPropTable = section.getParent() == null ? new HashMap() : getFinalPropTableNormal(section.getParent());
-        ((Map)finalPropTable).putAll(section.getNormalPriorityParams());
-        return (Map)finalPropTable;
+        finalPropTable.putAll(section.getNormalPriorityParams());
+        return finalPropTable;
     }
 
     public static <T extends Section> void replaceParametersInDescription(T section) {
@@ -438,14 +410,10 @@ public class KDTUtils {
 
     public static SourceProvider getSourceProviderFromObject(Object object) {
         if (object != null) {
-            Method[] var1 = object.getClass().getDeclaredMethods();
-            int var2 = var1.length;
-
-            for(int var3 = 0; var3 < var2; ++var3) {
-                Method method = var1[var3];
+            for (Method method : object.getClass().getDeclaredMethods()) {
                 if (SourceProvider.class.isAssignableFrom(method.getReturnType())) {
                     try {
-                        return (SourceProvider)method.invoke(object);
+                        return (SourceProvider) method.invoke(object);
                     } catch (Throwable var6) {
                     }
                 }
@@ -458,10 +426,8 @@ public class KDTUtils {
     public static void loadConfigParams(Executable executable) {
         Properties p = getAllConfigContent();
         if (p != null) {
-            Iterator var2 = p.entrySet().iterator();
-
-            while(var2.hasNext()) {
-                Map.Entry<Object, Object> prop = (Map.Entry)var2.next();
+            for (Map.Entry<Object, Object> objectObjectEntry : p.entrySet()) {
+                Map.Entry<Object, Object> prop = (Map.Entry) objectObjectEntry;
                 String key = String.valueOf(prop.getKey());
                 String value = String.valueOf(prop.getValue());
                 executable.setParam(key, value);
@@ -479,7 +445,7 @@ public class KDTUtils {
     }
 
     public static class StringSource implements SourceProvider {
-        private String source;
+        private final String source;
 
         public StringSource(String source) {
             this.source = source;
@@ -556,14 +522,9 @@ public class KDTUtils {
 
         public HtmlTableBuilder addHeaderRow(boolean doNotEscape, Object... cellValues) {
             this.buf.append("<tr>");
-            Object[] var3 = cellValues;
-            int var4 = cellValues.length;
-
-            for(int var5 = 0; var5 < var4; ++var5) {
-                Object value = var3[var5];
+            for (Object value : cellValues) {
                 this.buf.append("<th>").append(this.escapeValue(value, doNotEscape)).append("</th>");
             }
-
             this.buf.append("</tr>");
             return this;
         }
@@ -588,14 +549,9 @@ public class KDTUtils {
             }
 
             this.buf.append("<tr class='").append(clazz).append("'>");
-            Object[] var4 = cellValues;
-            int var5 = cellValues.length;
-
-            for(int var6 = 0; var6 < var5; ++var6) {
-                Object value = var4[var6];
+            for (Object value : cellValues) {
                 this.buf.append("<td class='").append(clazz).append("'>").append(this.escapeValue(value, doNotEscape)).append("</td>");
             }
-
             this.buf.append("</tr>");
             return this;
         }

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
@@ -62,7 +62,7 @@ public class AtpRamWriterHierarchyTest {
     @Mock
     private KafkaConfigurator kafkaConfigurator;
     private AtpKafkaRamAdapter adapter;
-    private Stack<LogRecord> expectedHierarchyLogRecords = new Stack<>();
+    private final Stack<LogRecord> expectedHierarchyLogRecords = new Stack<>();
 
     private static final UUID rootSectionId = UUID.randomUUID();
     private static final String rootSectionName = "Root Section";
@@ -83,7 +83,7 @@ public class AtpRamWriterHierarchyTest {
     private static final UUID rootLogRecordId = UUID.randomUUID();
     private static final String rootLogRecordName = "Root LogRecord";
 
-    private TestRunContext setUp(boolean stepIsLast) throws Exception {
+    private TestRunContext setUp(boolean stepIsLast) {
         try (MockedConstruction<KafkaConfigurator> mockKafkaConfigurator = Mockito.mockConstruction(KafkaConfigurator.class)) {
             try (MockedConstruction<KafkaProducer> mockKafkaProducer = Mockito.mockConstruction(KafkaProducer.class)) {
                 TestRunContext testRunContext = Utils.createTestRunContext(false);

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
@@ -38,6 +38,8 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 import org.qubership.atp.adapter.common.adapters.AtpKafkaRamAdapter;
 import org.qubership.atp.adapter.common.adapters.providers.RamAdapterProvider;
@@ -51,6 +53,7 @@ import org.qubership.atp.ram.enums.TestingStatuses;
 import org.qubership.atp.ram.models.LogRecord;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class AtpRamWriterHierarchyTest {
     private MockedStatic<TestRunContextHolder> mockedTestRunContextHolder;
     private MockedStatic<RamAdapterProvider> mockedRamAdapterProvider;

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ package org.qubership.atp.adapter.executor.executor;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.mockito.Mockito.mockStatic;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -29,18 +27,18 @@ import java.util.Stack;
 import java.util.UUID;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import org.qubership.atp.adapter.common.adapters.AtpKafkaRamAdapter;
 import org.qubership.atp.adapter.common.adapters.providers.RamAdapterProvider;
 import org.qubership.atp.adapter.common.context.AtpCompaund;
@@ -48,17 +46,15 @@ import org.qubership.atp.adapter.common.context.TestRunContext;
 import org.qubership.atp.adapter.common.context.TestRunContextHolder;
 import org.qubership.atp.adapter.common.entities.Message;
 import org.qubership.atp.adapter.common.kafka.client.KafkaConfigurator;
-import org.qubership.atp.adapter.common.kafka.pool.KafkaPoolManagementService;
-
+import org.qubership.atp.adapter.report.WebReportItem;
 import org.qubership.atp.ram.enums.TestingStatuses;
 import org.qubership.atp.ram.models.LogRecord;
-import org.qubership.atp.adapter.report.WebReportItem;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({KafkaPoolManagementService.class, AtpKafkaRamAdapter.class, RamAdapterProvider.class,
-        TestRunContextHolder.class})
-@PowerMockIgnore("javax.management.*")
+@ExtendWith(MockitoExtension.class)
 public class AtpRamWriterHierarchyTest {
+    private MockedStatic<TestRunContextHolder> mockedTestRunContextHolder;
+    private MockedStatic<RamAdapterProvider> mockedRamAdapterProvider;
+
     @Spy
     private org.qubership.atp.adapter.executor.executor.AtpRamWriter writer = new AtpRamWriter();
     @Mock
@@ -88,22 +84,32 @@ public class AtpRamWriterHierarchyTest {
     private static final String rootLogRecordName = "Root LogRecord";
 
     private TestRunContext setUp(boolean stepIsLast) throws Exception {
-        TestRunContext testRunContext = Utils.createTestRunContext(false);
-        testRunContext.setCompoundAndUpdateCompoundStatuses(Utils.createAtpCompaund(stepIsLast));
-        whenNew(KafkaProducer.class).withAnyArguments().thenReturn(producer);
-        whenNew(KafkaConfigurator.class).withAnyArguments().thenReturn(kafkaConfigurator);
+        try (MockedConstruction<KafkaConfigurator> mockKafkaConfigurator = Mockito.mockConstruction(KafkaConfigurator.class)) {
+            try (MockedConstruction<KafkaProducer> mockKafkaProducer = Mockito.mockConstruction(KafkaProducer.class)) {
+                TestRunContext testRunContext = Utils.createTestRunContext(false);
+                testRunContext.setCompoundAndUpdateCompoundStatuses(Utils.createAtpCompaund(stepIsLast));
 
-        adapter = Mockito.spy(AtpKafkaRamAdapter.class);
-        adapter.setContext(testRunContext);
+                adapter = Mockito.spy(AtpKafkaRamAdapter.class);
+                adapter.setContext(testRunContext);
+                mockedRamAdapterProvider.when(() -> RamAdapterProvider.getNewAdapter(anyString())).thenReturn(adapter);
+                mockedTestRunContextHolder.when(() -> TestRunContextHolder.getContext(anyString())).thenReturn(testRunContext);
 
-        mockStatic(RamAdapterProvider.class);
-        when(RamAdapterProvider.getNewAdapter(anyString())).thenReturn(adapter);
+                createExpectedHierarchyLogRecords();
+                return testRunContext;
+            }
+        }
+    }
 
-        mockStatic(TestRunContextHolder.class);
-        when(TestRunContextHolder.getContext(anyString())).thenReturn(testRunContext);
+    @BeforeEach
+    void setUpStaticMocks() {
+        mockedTestRunContextHolder = mockStatic(TestRunContextHolder.class);
+        mockedRamAdapterProvider = mockStatic(RamAdapterProvider.class);
+    }
 
-        createExpectedHierarchyLogRecords();
-        return testRunContext;
+    @AfterEach
+    void tearDownStaticMocks() {
+        mockedRamAdapterProvider.closeOnDemand();
+        mockedTestRunContextHolder.closeOnDemand();
     }
 
     /**
@@ -115,21 +121,21 @@ public class AtpRamWriterHierarchyTest {
     public void testHierarchyLogRecords_CheckCompoundStatus_CompoundStatusIsFailed() throws Exception {
         Stack<LogRecord> result = executeWithTwoSteps();
 
-        Assert.assertEquals(3, result.size());
+        Assertions.assertEquals(3, result.size());
 
         LogRecord compound = result.pop();
         boolean compoundIdEqualsExpectedId = compound.getUuid().equals(Utils.compaundId);
         boolean compoundStatusEqualsExpectedStatus =
                 compound.getTestingStatus().getName().equals(TestingStatuses.FAILED.getName());
-        Assert.assertTrue(String.format("Compound [%s] with status FAILED is expected last in the stack. AR: id [%s], "
-                        + "status [%s]", Utils.compaundId, compound.getUuid(), compound.getTestingStatus()),
-                compoundIdEqualsExpectedId && compoundStatusEqualsExpectedStatus);
+        Assertions.assertTrue(compoundIdEqualsExpectedId && compoundStatusEqualsExpectedStatus,
+                String.format("Compound [%s] with status FAILED is expected last in the stack. AR: id [%s], "
+                        + "status [%s]", Utils.compaundId, compound.getUuid(), compound.getTestingStatus()));
 
         LogRecord step = result.pop();
-        Assert.assertTrue(String.format("Step [%s] with parent [%s] and status FAILED expected after compound. AR: id "
+        Assertions.assertTrue(verifyLogRecord(Utils.stepId, Utils.compaundId, TestingStatuses.FAILED, step),
+                String.format("Step [%s] with parent [%s] and status FAILED expected after compound. AR: id "
                         + "[%s], "
-                        + "parentId [%s]", Utils.stepId, Utils.compaundId, step.getUuid(), step.getParentRecordId()),
-                verifyLogRecord(Utils.stepId, Utils.compaundId, TestingStatuses.FAILED, step));
+                        + "parentId [%s]", Utils.stepId, Utils.compaundId, step.getUuid(), step.getParentRecordId()));
     }
 
     /**
@@ -150,80 +156,80 @@ public class AtpRamWriterHierarchyTest {
             throws Exception {
         Stack<LogRecord> result = execute();
 
-        Assert.assertEquals(11, result.size());
+        Assertions.assertEquals(11, result.size());
         LogRecord compound = result.pop();
         boolean parentCompoundIsNull = Objects.isNull(compound.getParentRecordId());
         boolean compoundIdEqualsExpectedId = compound.getUuid().equals(Utils.compaundId);
         boolean compoundStatusEqualsExpectedStatus =
                 compound.getTestingStatus().getName().equals(TestingStatuses.FAILED.getName());
-        Assert.assertTrue(String.format("Compound [%s] with parent [%s] is expected last in the stack. AR: id [%s], "
-                        + "parentId [%s]", Utils.compaundId, null, compound.getUuid(), compound.getParentRecordId()),
-                parentCompoundIsNull && compoundIdEqualsExpectedId && compoundStatusEqualsExpectedStatus);
+        Assertions.assertTrue(parentCompoundIsNull && compoundIdEqualsExpectedId && compoundStatusEqualsExpectedStatus,
+                String.format("Compound [%s] with parent [%s] is expected last in the stack. AR: id [%s], "
+                        + "parentId [%s]", Utils.compaundId, null, compound.getUuid(), compound.getParentRecordId()));
 
         LogRecord step = result.pop();
-        Assert.assertTrue(String.format("Step [%s] with parent [%s] expected after compound. AR: id [%s], "
-                        + "parentId [%s]", Utils.stepId, Utils.compaundId, step.getUuid(), step.getParentRecordId()),
-                verifyLogRecord(Utils.stepId, Utils.compaundId, TestingStatuses.FAILED, step));
+        Assertions.assertTrue(verifyLogRecord(Utils.stepId, Utils.compaundId, TestingStatuses.FAILED, step),
+                String.format("Step [%s] with parent [%s] expected after compound. AR: id [%s], "
+                        + "parentId [%s]", Utils.stepId, Utils.compaundId, step.getUuid(), step.getParentRecordId()));
 
         LogRecord rootSection = result.pop();
-        Assert.assertTrue(String.format("Root section [%s] with parent [%s] expected after Step. AR: id [%s], "
+        Assertions.assertTrue(verifyLogRecord(rootSectionId, Utils.stepId, TestingStatuses.FAILED,
+                rootSection), String.format("Root section [%s] with parent [%s] expected after Step. AR: id [%s], "
                         + "parentId [%s]", rootSectionId, Utils.stepId, rootSection.getUuid(),
-                rootSection.getParentRecordId()), verifyLogRecord(rootSectionId, Utils.stepId, TestingStatuses.FAILED,
-                rootSection));
+                rootSection.getParentRecordId()));
 
         LogRecord rootLogRecord = result.pop();
-        Assert.assertTrue(String.format("Root Log Record [%s] with parent [%s] expected last in the Root Section. "
+        Assertions.assertTrue(verifyLogRecord(rootLogRecordId, rootSectionId,
+                TestingStatuses.PASSED, rootLogRecord), String.format("Root Log Record [%s] with parent [%s] expected last in the Root Section. "
                         + "AR: id [%s], parentId [%s]", rootLogRecordId, rootSectionId, rootLogRecord.getUuid(),
-                rootLogRecord.getParentRecordId()), verifyLogRecord(rootLogRecordId, rootSectionId,
-                TestingStatuses.PASSED, rootLogRecord));
+                rootLogRecord.getParentRecordId()));
 
         LogRecord section2 = result.pop();
-        Assert.assertTrue(String.format("Section2 [%s] with parent [%s] expected in the Root Section. AR: id [%s], "
-                        + "parentId [%s]", section2Id, rootSectionId, section2.getUuid(), section2.getParentRecordId()),
-                verifyLogRecord(section2Id, rootSectionId, TestingStatuses.FAILED, section2));
+        Assertions.assertTrue(verifyLogRecord(section2Id, rootSectionId, TestingStatuses.FAILED, section2),
+                String.format("Section2 [%s] with parent [%s] expected in the Root Section. AR: id [%s], "
+                        + "parentId [%s]", section2Id, rootSectionId, section2.getUuid(), section2.getParentRecordId()));
 
         LogRecord section21 = result.pop();
-        Assert.assertTrue(String.format("Section21 [%s] with parent [%s] expected in the Section2. "
+        Assertions.assertTrue(verifyLogRecord(section21Id, section2Id, TestingStatuses.FAILED,
+                section21), String.format("Section21 [%s] with parent [%s] expected in the Section2. "
                         + "AR: id [%s], parentId [%s]", section21Id, section2Id, section21.getUuid(),
-                section21.getParentRecordId()), verifyLogRecord(section21Id, section2Id, TestingStatuses.FAILED,
-                section21));
+                section21.getParentRecordId()));
 
         LogRecord logRecord212 = result.pop();
-        Assert.assertTrue(String.format("Log Record 212 [%s] with parent [%s] expected last in the Section21. "
+        Assertions.assertTrue(verifyLogRecord(logRecord212Id, section21Id,
+                TestingStatuses.FAILED, logRecord212), String.format("Log Record 212 [%s] with parent [%s] expected last in the Section21. "
                         + "AR: id [%s], parentId [%s]", logRecord212Id, section21Id, logRecord212.getUuid(),
-                logRecord212.getParentRecordId()), verifyLogRecord(logRecord212Id, section21Id,
-                TestingStatuses.FAILED, logRecord212));
+                logRecord212.getParentRecordId()));
 
         LogRecord logRecord211 = result.pop();
-        Assert.assertTrue(String.format("Log Record 211 [%s] with parent [%s] expected in the Section21. "
+        Assertions.assertTrue(verifyLogRecord(logRecord211Id, section21Id,
+                TestingStatuses.PASSED, logRecord211), String.format("Log Record 211 [%s] with parent [%s] expected in the Section21. "
                         + "AR: id [%s], parentId [%s]", logRecord211Id, section21Id, logRecord211.getUuid(),
-                logRecord211.getParentRecordId()), verifyLogRecord(logRecord211Id, section21Id,
-                TestingStatuses.PASSED, logRecord211));
+                logRecord211.getParentRecordId()));
 
         LogRecord section1 = result.pop();
-        Assert.assertTrue(String.format("Section1 [%s] with parent [%s] expected first in the Root Section. "
+        Assertions.assertTrue(verifyLogRecord(section1Id, rootSectionId, TestingStatuses.PASSED,
+                section1), String.format("Section1 [%s] with parent [%s] expected first in the Root Section. "
                         + "AR: id [%s], parentId [%s]", section1Id, rootSectionId, section1.getUuid(),
-                section1.getParentRecordId()), verifyLogRecord(section1Id, rootSectionId, TestingStatuses.PASSED,
-                section1));
+                section1.getParentRecordId()));
 
         LogRecord logRecord12 = result.pop();
-        Assert.assertTrue(String.format("Log Record 12 [%s] with parent [%s] expected last in the Section1. "
+        Assertions.assertTrue(verifyLogRecord(logRecord12Id, section1Id,
+                TestingStatuses.PASSED, logRecord12), String.format("Log Record 12 [%s] with parent [%s] expected last in the Section1. "
                         + "AR: id [%s], parentId [%s]", logRecord12Id, section1Id, logRecord12.getUuid(),
-                logRecord12.getParentRecordId()), verifyLogRecord(logRecord12Id, section1Id,
-                TestingStatuses.PASSED, logRecord12));
+                logRecord12.getParentRecordId()));
 
         LogRecord logRecord11 = result.pop();
-        Assert.assertTrue(String.format("Log Record 11 [%s] with parent [%s] expected in the Section1. "
+        Assertions.assertTrue(verifyLogRecord(logRecord11Id, section1Id, TestingStatuses.PASSED,
+                logRecord11), String.format("Log Record 11 [%s] with parent [%s] expected in the Section1. "
                         + "AR: id [%s], parentId [%s]", logRecord11Id, section1Id, logRecord11.getUuid(),
-                logRecord11.getParentRecordId()), verifyLogRecord(logRecord11Id, section1Id, TestingStatuses.PASSED,
-                logRecord11));
+                logRecord11.getParentRecordId()));
     }
 
     private Stack<LogRecord> execute() throws Exception {
         TestRunContext testRunContext = setUp(true);
         Stack<LogRecord> result = new Stack<>();
         createAnswers(result, testRunContext);
-        PowerMockito.doReturn(testRunContext).when(adapter).startAtpRun(any(), any());
+        Mockito.doReturn(testRunContext).when(adapter).startAtpRun(any(), any());
         writer.openLog(testRunContext.getTestRunId());
 
         openSection(rootSectionName, "", rootSectionId.toString());
@@ -251,7 +257,7 @@ public class AtpRamWriterHierarchyTest {
         Stack<LogRecord> result = new Stack<>();
         createAnswers(result, testRunContext);
 
-        PowerMockito.doReturn(testRunContext).when(adapter).startAtpRun(any(), any());
+        Mockito.doReturn(testRunContext).when(adapter).startAtpRun(any(), any());
         writer.openLog(testRunContext.getTestRunId());
 
         message(logRecord11Name, "message", logRecord11Id.toString(), TestingStatuses.FAILED);
@@ -296,8 +302,8 @@ public class AtpRamWriterHierarchyTest {
             result.push(logRecord);
             return writer.getAdapter().getContext();
         };
-        PowerMockito.doAnswer(answer).when(adapter).sendLogRecord(any(LogRecord.class));
-        PowerMockito.doAnswer(answerFotUpdateStatus).when(adapter).updateTestingStatus(anyString(), anyString());
+        Mockito.doAnswer(answer).when(adapter).sendLogRecord(any(LogRecord.class));
+        Mockito.doAnswer(answerFotUpdateStatus).when(adapter).updateTestingStatus(anyString(), anyString());
     }
 
     private boolean verifyLogRecord(UUID expectedId, UUID expectedParentId,

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,47 +16,42 @@
 
 package org.qubership.atp.adapter.executor.executor;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.qubership.atp.adapter.executor.executor.Utils.createAtpCompaund;
 import static org.qubership.atp.adapter.executor.executor.Utils.createTestRunContext;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 
-//import org.qubership.atp.adapter.wd.shell.elements.common.Page;
-import org.apache.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import org.qubership.atp.adapter.common.RamConstants;
 import org.qubership.atp.adapter.common.adapters.AtpReceiverRamAdapter;
 import org.qubership.atp.adapter.common.context.AtpCompaund;
 import org.qubership.atp.adapter.common.context.TestRunContext;
 import org.qubership.atp.adapter.common.context.TestRunContextHolder;
 import org.qubership.atp.adapter.common.entities.Message;
-
+import org.qubership.atp.adapter.report.WebReportItem;
 import org.qubership.atp.ram.enums.TestingStatuses;
 import org.qubership.atp.ram.enums.TypeAction;
-import org.qubership.atp.adapter.report.WebReportItem;
 
-import java.io.File;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({TestRunContextHolder.class})
 public class AtpRamWriterTest {
+    private MockedStatic<TestRunContextHolder> mockedTestRunContextHolder;
     private org.qubership.atp.adapter.executor.executor.AtpRamWriter writer = Mockito.spy(new AtpRamWriter());
     private AtpReceiverRamAdapter atpReceiverRamAdapter = Mockito.mock(AtpReceiverRamAdapter.class);
 
-    @Before
+    @BeforeEach
     public void setUp() {
+      mockedTestRunContextHolder = mockStatic(TestRunContextHolder.class);
         Mockito.when(writer.getAdapter()).thenReturn(atpReceiverRamAdapter);
+    }
+
+    @AfterEach
+    void tearDownStaticMocks() {
+        mockedTestRunContextHolder.closeOnDemand();
     }
 
     @Test
@@ -92,11 +87,8 @@ public class AtpRamWriterTest {
         section.setTestingStatus(TestingStatuses.UNKNOWN.toString());
         section.setSection(true);
 
-        /*Mockito.verify(atpReceiverRamAdapter)
-                .openSection("Step", "", "1", logRecordUuid.toString(), RamConstants.PASSED);*/
         Mockito.verify(atpReceiverRamAdapter).openSection(section);
     }
-
 
     @Test
     public void openSection_openSectionOnlyWithTitle_rootSectionIsOpened() {
@@ -116,34 +108,12 @@ public class AtpRamWriterTest {
         Mockito.verify(atpReceiverRamAdapter).openSection(section);
     }
 
-//    @Test
-//    public void deletingScreenshot_callDelete_screenshotDeleted() throws Exception {
-//        setMocks(createTestRunContext(true));
-//        File screenFile = new File("screen-thread-50-1660904215745.png");
-//        screenFile.createNewFile();
-//        Page mock = mockPage();
-//        writer.message("title", Level.INFO,"message",mock,null,null);
-//        assertFalse("Error during file deletion",screenFile.exists());
-//    }
-
-//    private Page mockPage() {
-//        String exampleSource = "<html><body><a href='http://127.0.0.1/main/homepage'>http://127.0.0.1/main/homepage</a><br/><img src='screen-thread-50-1660904215745.png' style='max-width:auto%; height:96%; min-height:500px;'></body></html>";
-//        Page mock = Mockito.mock(Page.class,RETURNS_DEEP_STUBS);
-//        when(mock.getReportType()).thenReturn("SCREENSHOT");
-//        when(mock.getExtension()).thenReturn("html");
-//        when(mock.getSource()).thenReturn(exampleSource);
-//        return mock;
-//    }
-
     private void setMocks(TestRunContext testRunContext) {
         Mockito.when(atpReceiverRamAdapter.startAtpRun(any(), any())).thenReturn(testRunContext);
-        mockStatic(TestRunContextHolder.class);
-        when(TestRunContextHolder.getContext(any())).thenReturn(testRunContext);
-        when(TestRunContextHolder.hasContext(any())).thenReturn(true);
+        mockedTestRunContextHolder.when(() -> TestRunContextHolder.getContext(any())).thenReturn(testRunContext);
+        mockedTestRunContextHolder.when(() -> TestRunContextHolder.hasContext(any())).thenReturn(true);
         writer.createContext(testRunContext.getTestRunId());
         doCallRealMethod().when(writer).openSection(any(WebReportItem.OpenSection.class));
         Mockito.when(atpReceiverRamAdapter.openSection(any(), any(), any(), any(), any())).thenReturn(testRunContext);
     }
-
-
 }

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AtpRamWriterTest.java
@@ -40,8 +40,8 @@ import org.qubership.atp.ram.enums.TypeAction;
 
 public class AtpRamWriterTest {
     private MockedStatic<TestRunContextHolder> mockedTestRunContextHolder;
-    private org.qubership.atp.adapter.executor.executor.AtpRamWriter writer = Mockito.spy(new AtpRamWriter());
-    private AtpReceiverRamAdapter atpReceiverRamAdapter = Mockito.mock(AtpReceiverRamAdapter.class);
+    private final org.qubership.atp.adapter.executor.executor.AtpRamWriter writer = Mockito.spy(new AtpRamWriter());
+    private final AtpReceiverRamAdapter atpReceiverRamAdapter = Mockito.mock(AtpReceiverRamAdapter.class);
 
     @BeforeEach
     public void setUp() {

--- a/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AttachmentCreatorTest.java
+++ b/qubership-atp-adapter-executor/src/test/java/org/qubership/atp/adapter/executor/executor/AttachmentCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,14 +20,12 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.adapter.executor.executor.sourceproviders.CommonFileSourceProvider;
 import org.qubership.atp.adapter.executor.executor.sourceproviders.FileSource;
 import org.qubership.atp.adapter.executor.executor.sourceproviders.TestSnapshot;
 import org.qubership.atp.adapter.executor.executor.sourceproviders.TestSnapshotWithoutExtension;
-
 import org.qubership.atp.adapter.executor.executor.utils.AttachmentCreator;
 import org.qubership.atp.adapter.executor.executor.utils.MimeType;
 import org.qubership.atp.ram.models.logrecords.parts.FileMetadata;
@@ -43,10 +41,10 @@ public class AttachmentCreatorTest {
 
         org.qubership.atp.adapter.executor.executor.NttAttachment attachment = AttachmentCreator.create(new CommonFileSourceProvider(fileContent, fileName));
 
-        Assert.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
-        Assert.assertEquals(fileName, attachment.getFileName());
-        Assert.assertEquals(fileContent, attachment.getFileSource().toString());
-        Assert.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
+        Assertions.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
+        Assertions.assertEquals(fileName, attachment.getFileName());
+        Assertions.assertEquals(fileContent, attachment.getFileSource().toString());
+        Assertions.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
     }
 
     @Test
@@ -59,10 +57,10 @@ public class AttachmentCreatorTest {
 
         org.qubership.atp.adapter.executor.executor.NttAttachment attachment = AttachmentCreator.create(new FileSource(fileName));
 
-        Assert.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
-        Assert.assertEquals(fileName, attachment.getFileName());
-        Assert.assertEquals(fileName, attachment.getFileSource().toString());
-        Assert.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
+        Assertions.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
+        Assertions.assertEquals(fileName, attachment.getFileName());
+        Assertions.assertEquals(fileName, attachment.getFileSource().toString());
+        Assertions.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
     }
 
     @Test
@@ -74,10 +72,10 @@ public class AttachmentCreatorTest {
 
         org.qubership.atp.adapter.executor.executor.NttAttachment attachment = AttachmentCreator.create(new TestSnapshot(fileContent));
 
-        Assert.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
-        Assert.assertEquals(fileNameWithExtension, attachment.getFileName());
-        Assert.assertTrue(attachment.getFileSource().getName().startsWith(fileName));
-        Assert.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
+        Assertions.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
+        Assertions.assertEquals(fileNameWithExtension, attachment.getFileName());
+        Assertions.assertTrue(attachment.getFileSource().getName().startsWith(fileName));
+        Assertions.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
         attachment.getFileSource().delete();
     }
 
@@ -90,10 +88,10 @@ public class AttachmentCreatorTest {
 
         NttAttachment attachment = AttachmentCreator.create(new TestSnapshotWithoutExtension(fileContent));
 
-        Assert.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
-        Assert.assertEquals(fileNameWithExtension, attachment.getFileName());
-        Assert.assertTrue(attachment.getFileSource().getName().startsWith(fileName));
-        Assert.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
+        Assertions.assertEquals(MimeType.HTML.toString(), attachment.getContentType());
+        Assertions.assertEquals(fileNameWithExtension, attachment.getFileName());
+        Assertions.assertTrue(attachment.getFileSource().getName().startsWith(fileName));
+        Assertions.assertEquals(expectedFileMetadata, attachment.getFileMetadata());
         attachment.getFileSource().delete();
     }
 }

--- a/qubership-atp-adapter-robot-distribution/pom.xml
+++ b/qubership-atp-adapter-robot-distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-robot-distribution/pom.xml
+++ b/qubership-atp-adapter-robot-distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>4.5.73-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-robot-distribution/pom.xml
+++ b/qubership-atp-adapter-robot-distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-dependencies</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../parent/parent-dependencies/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-robot/pom.xml
+++ b/qubership-atp-adapter-robot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-robot/pom.xml
+++ b/qubership-atp-adapter-robot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>4.5.73-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 
@@ -43,14 +43,14 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.14.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -228,7 +228,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.20.1</version>
+                        <version>3.1.2</version>
                         <executions>
                             <!-- execute all integration (mostly UI tests) -->
                             <execution>

--- a/qubership-atp-adapter-robot/pom.xml
+++ b/qubership-atp-adapter-robot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.adapter.robot</groupId>
         <artifactId>qubership-atp-adapter-robot-parent-java</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../parent/parent-java/pom.xml</relativePath>
     </parent>
 

--- a/qubership-atp-adapter-robot/src/test/java/org/qubership/atp/adapter/robot/RamListenerTest.java
+++ b/qubership-atp-adapter-robot/src/test/java/org/qubership/atp/adapter/robot/RamListenerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 
 package org.qubership.atp.adapter.robot;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.adapter.robot.utils.ScreenShotHelper;
-
 
 public class RamListenerTest {
     @Test
@@ -28,6 +26,6 @@ public class RamListenerTest {
         String messageText = "</td></tr><tr><td colspan=\"3\"><a href=\"selenium-screenshot-1.png\"><img src=\"selenium-screenshot-1.png\" width=\"800px\"></a>";
         ScreenShotHelper helper = new ScreenShotHelper();
         String imgName = helper.extractImage(messageText);
-        Assert.assertEquals("selenium-screenshot-1.png", imgName);
+        Assertions.assertEquals("selenium-screenshot-1.png", imgName);
     }
 }

--- a/qubership-atp-adapter-robot/src/test/java/org/qubership/atp/adapter/robot/utils/ExecutionRequestHelperTest.java
+++ b/qubership-atp-adapter-robot/src/test/java/org/qubership/atp/adapter/robot/utils/ExecutionRequestHelperTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024-2025 NetCracker Technology Corporation
+ *  Copyright 2024-2026 NetCracker Technology Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,9 +19,8 @@ package org.qubership.atp.adapter.robot.utils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.adapter.common.utils.ExecutionRequestHelper;
 
 public class ExecutionRequestHelperTest {
@@ -31,6 +30,6 @@ public class ExecutionRequestHelperTest {
         String requestName = ExecutionRequestHelper.generateRequestName();
         Pattern p = Pattern.compile("(Default)\\s(ER)\\s(\\d{1,2})\\.(\\d{1,2})\\.(\\d{4}) (\\d{1,2}):(\\d{2})");
         Matcher m = p.matcher(requestName);
-        Assert.assertTrue(m.matches());
+        Assertions.assertTrue(m.matches());
     }
 }


### PR DESCRIPTION
Due to Security reasons, adapter-robot library is upgraded to Spring Boot 3.5.14.
(Spring Boot itself is not used in the library, but dependencies should be upgraded to the same versions as Spring Boot 3.5.14 uses or compatible).
Unit tests are migrated from Junit 4 to Junit Jupiter 5 + Mockito.
<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/d622d57a48d5d936b0470463071e079a35fd4524) feat: Upgrade to support services running on Spring Boot 3.3.x+: initial changes made by OpenRewrite plugin. atp-crypt dependency version is changed to 1.0.0-SNAPSHOT. Project version is changed to 5.0.0-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/0dcfab03d01a25b4bf6e87b0711ab5e8f3172bd9) refactor: Code is rewritten to avoid redundant operations and cleansed. Also: jakarta.annotation-api:2.1.1 dependency is added.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/8c2ac849ebd931c09dfbff7e9e980eeb9e473bbc) feat: Migration to httpclient5 is performed. Dependencies to httpclient5:5.4.4 and httpcore5:5.3.4 are added.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/af1b8f13242a2db5a36c277bccaeb7725e8e053f) fix: junit dependency is removed. AtpRamWriterHierarchyTest: test is fixed by setting Mockito Strictness to LENIENT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/f4dcdca696c9007528c08d4227eafb052d0ba8fd) chore(deps): Duplicate GitHub workflow changes from main.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/d25b6d70ffd92e4d1ab8debf3068e798d815460f) feat: Upgrade to support services on Spring Boot 3.5.14: Changes by OpenRewrite plugin.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/70d2e3d97e7118fa507cd95429495dfded9290fd) fix(deps): Bump atp-crypt version to 1.0.1-SNAPSHOT. Also: Set project version to 5.0.1-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/9300c1602a421c4c13410d039a36dd010a31d4b1) fix(deps): Bump dependencies: guava to 32.0.1-jre, jackson to 2.18.6, logback to 1.5.32, kafka-clients to 3.9.2, postgresql to 42.7.7, slf4j to 2.0.17, netty to 4.1.132.Final, undertow-core to 2.3.21.Final, mapstruct to 1.6.3.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/27cb4245a20a8cadc0a58d52c52114c54b02b80d) Merge branch 'main' into feature/upgrade-for-springboot-3-5-14

# Conflicts:
#	.github/workflows/maven-central-snapshot-deploy.yaml
#	.github/workflows/maven-release-v2.yaml
#	.github/workflows/pr-assigner.yml
#	.github/workflows/pr-conventional-commits.yaml
#	.github/workflows/profanity-filter.yaml
#	.github/workflows/super-linter.yaml
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/e67f605d0a388e4ea5a1636096c50be13a08b6f8) build: Project version is set to 5.0.0-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/d72756a69af816a07d545bd0d20511fcc06fa75f) fix(deps): Bump atp-crypt to 1.0.0. Also: Improve dependencies management.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-adapter-robot-library/commit/28eed50085baea50bd47715ffbc46ad20b6c717c) fix: Fix SPELL_CODESPELL errors, remove unused properties from pom.xml.
<!-- end messages -->
